### PR TITLE
WIP: BinSync Plugin Registry

### DIFF
--- a/binsync/common/controller.py
+++ b/binsync/common/controller.py
@@ -463,6 +463,29 @@ class BinSyncController:
         return None
 
     #
+    # Change Callback API
+    #
+
+    def on_function_header_changed(self, fheader: FunctionHeader):
+        pass
+
+    def on_stack_variable_changed(self, svar: StackVariable):
+        pass
+
+    def on_comment_changed(self, comment: Comment):
+        pass
+
+    def on_struct_changed(self, struct: Struct):
+        pass
+
+    def on_enum_changed(self, enum: Enum):
+        pass
+
+    def on_global_variable_changed(self, gvar: GlobalVariable):
+        pass
+
+
+    #
     # Client API & Shortcuts
     #
 

--- a/binsync/plugins/base_plugin.py
+++ b/binsync/plugins/base_plugin.py
@@ -1,0 +1,10 @@
+from ..common.controller import BinSyncController
+
+class BaseBSPlugin:
+    TOP_MENU_NAME = ""
+
+    def __init__(self, controller: BinSyncController):
+        self.controller = controller
+
+    def register_bs_menu_item(self, item_str, callback_function):
+        pass

--- a/binsync/plugins/enabled_plugins.toml
+++ b/binsync/plugins/enabled_plugins.toml
@@ -1,0 +1,2 @@
+[enabled]
+example-bs-plugin = "example_bs_plugin"

--- a/binsync/plugins/plugin_registry.py
+++ b/binsync/plugins/plugin_registry.py
@@ -1,0 +1,10 @@
+class PluginRegistry:
+    def __init__(self):
+        pass
+
+    def discover_plugins(self, directory):
+        pass
+
+    def load_plugins(self):
+        pass
+


### PR DESCRIPTION
## BinSync Plugin Registry
A new system for others to develop plugins for BinSync, which can then be run in any decompiler.
Example code use:
```python
from binsync.controller import get_decompiler_controller, BinSyncController
# gets you the correct controller for your decompiler
controller: BinSyncController = get_decompiler_controller()
controller.on_struct_change = lambda x: print(f"struct changed {x}")
for function in controller.functions:
    print(function.name, function.type)
```

This code could be run in ANY decompiler BinSync is loaded in. 
