### PR TITLE
Add UI in Utils tab to disable atuo commit, push, and pull

### DIFF
--- a/binsync/__init__.py
+++ b/binsync/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.11.1"
+__version__ = "3.12.0"
 
 #
 # logging

--- a/binsync/core/client.py
+++ b/binsync/core/client.py
@@ -79,6 +79,7 @@ class Client:
         ssh_auth_sock: Optional[str] = None,
         push_on_update=True,
         pull_on_update=True,
+        commit_on_update=True,
         **kwargs,
     ):
         """
@@ -104,6 +105,7 @@ class Client:
         self.repo_lock = None
         self.pull_on_update = pull_on_update
         self.push_on_update = push_on_update
+        self.commit_on_update = commit_on_update
 
         # validate this username can exist
         if not master_user or master_user.endswith('/') or '__root__' in master_user:

--- a/binsync/decompiler_stubs/binja_binsync/plugin.json
+++ b/binsync/decompiler_stubs/binja_binsync/plugin.json
@@ -15,7 +15,7 @@
 		"Linux" : "Install through the Binja Plugin Manager. To update do `pip install -U binsync`",
 		"Windows" : "Install through the Binja Plugin Manager. To update do `pip install -U binsync`"
 	},
-	"version": "3.10.14",
+	"version": "3.12.0",
 	"author": "BinSync Team",
 	"minimumbinaryninjaversion": 1200
 }

--- a/binsync/decompiler_stubs/binja_binsync/requirements.txt
+++ b/binsync/decompiler_stubs/binja_binsync/requirements.txt
@@ -1,1 +1,1 @@
-binsync>=3.10.14
+binsync>=3.12.0

--- a/binsync/ui/panel_tabs/util_panel.py
+++ b/binsync/ui/panel_tabs/util_panel.py
@@ -91,14 +91,17 @@ class QUtilPanel(QWidget):
         self._auto_commit = QCheckBox("Disable Auto Committing")
         self._auto_commit.setToolTip("Disables the automatic committing of changes to your user branch. Any changes"
                                     "you make during this time will not be recorded by BinSync.")
+        self._auto_commit.setChecked(not self.controller.auto_commit_enabled)
         self._auto_commit.stateChanged.connect(self._handle_auto_commit_toggle)
 
         self._auto_push = QCheckBox("Disable Auto Pushing")
         self._auto_push.setToolTip("Disables the automatic pushing of commits to your user branch.")
+        self._auto_push.setChecked(not self.controller.auto_push_enabled)
         self._auto_push.stateChanged.connect(self._handle_auto_push_toggle)
 
         self._auto_pull = QCheckBox("Disable Auto Pulling")
         self._auto_pull.setToolTip("Disables the automatic pulling of commits from ALL branches.")
+        self._auto_pull.setChecked(not self.controller.auto_pull_enabled)
         self._auto_pull.stateChanged.connect(self._handle_auto_pull_toggle)
         dev_options_layout.addWidget(self._auto_commit)
         dev_options_layout.addWidget(self._auto_push)

--- a/binsync/ui/panel_tabs/util_panel.py
+++ b/binsync/ui/panel_tabs/util_panel.py
@@ -31,20 +31,6 @@ class QUtilPanel(QWidget):
     def _init_widgets(self):
 
         #
-        # Developer Options Group
-        #
-
-        dev_options_group = QGroupBox()
-        dev_options_layout = QVBoxLayout()
-        dev_options_group.setTitle("Developer Options")
-        dev_options_group.setLayout(dev_options_layout)
-
-        self._debug_log_toggle = QCheckBox("Toggle Debug Logging")
-        self._debug_log_toggle.setToolTip("Toggles the logging of events BinSync developers care about.")
-        self._debug_log_toggle.stateChanged.connect(self._handle_debug_toggle)
-        dev_options_layout.addWidget(self._debug_log_toggle)
-
-        #
         # Sync Options Group
         #
 
@@ -87,6 +73,37 @@ class QUtilPanel(QWidget):
         sync_options_layout.addLayout(sync_level_layout)
         sync_options_group.layout().addWidget(self._magic_sync_button)
         sync_options_group.layout().addWidget(self._force_push_button)
+
+        #
+        # Developer Options Group
+        #
+
+        dev_options_group = QGroupBox()
+        dev_options_layout = QVBoxLayout()
+        dev_options_group.setTitle("Developer Options")
+        dev_options_group.setLayout(dev_options_layout)
+
+        self._debug_log_toggle = QCheckBox("Toggle Debug Logging")
+        self._debug_log_toggle.setToolTip("Toggles the logging of events BinSync developers care about.")
+        self._debug_log_toggle.stateChanged.connect(self._handle_debug_toggle)
+        dev_options_layout.addWidget(self._debug_log_toggle)
+
+        self._auto_commit = QCheckBox("Disable Auto Committing")
+        self._auto_commit.setToolTip("Disables the automatic committing of changes to your user branch. Any changes"
+                                    "you make during this time will not be recorded by BinSync.")
+        self._auto_commit.stateChanged.connect(self._handle_auto_commit_toggle)
+
+        self._auto_push = QCheckBox("Disable Auto Pushing")
+        self._auto_push.setToolTip("Disables the automatic pushing of commits to your user branch.")
+        self._auto_push.stateChanged.connect(self._handle_auto_push_toggle)
+
+        self._auto_pull = QCheckBox("Disable Auto Pulling")
+        self._auto_pull.setToolTip("Disables the automatic pulling of commits from ALL branches.")
+        self._auto_pull.stateChanged.connect(self._handle_auto_pull_toggle)
+        dev_options_layout.addWidget(self._auto_commit)
+        dev_options_layout.addWidget(self._auto_push)
+        dev_options_layout.addWidget(self._auto_pull)
+
 
         #
         # UI Options Group
@@ -226,3 +243,25 @@ class QUtilPanel(QWidget):
     def _handle_force_push_button(self):
         self.popup = ForcePushUI(self.controller)
         self.popup.show()
+
+    def _handle_auto_commit_toggle(self, state):
+        if state == Qt.Checked:
+            l.info(f"Disabling auto-commit!")
+            self.controller.auto_commit_enabled = False
+        else:
+            self.controller.auto_commit_enabled = True
+
+    def _handle_auto_push_toggle(self, state):
+        if state == Qt.Checked:
+            l.info(f"Disabling auto-push!")
+            self.controller.auto_push_enabled = False
+        else:
+            self.controller.auto_push_enabled = True
+
+    def _handle_auto_pull_toggle(self, state):
+        if state == Qt.Checked:
+            l.info(f"Disabling auto-pull!")
+            self.controller.auto_pull_enabled = False
+        else:
+            self.controller.auto_pull_enabled = True
+


### PR DESCRIPTION
Closes #292 

## Features
![image](https://github.com/binsync/binsync/assets/21327264/ffcbb32e-bd8c-49d3-a8af-6ef9a1fb9bfd)

Disabling auto-commit will stop any changes you make from being recorded. Disabling auto-push will not disable the recording of changes, but just the pushing of them to remote. Disable auto-pull will disable the automatic pulling of all branches (which is how BinSync updates). Use a combination of these to get varying effects. 
