### PR TITLE
Fix sorting by last_push in tables

### DIFF
--- a/binsync/ui/panel_tabs/activity_table.py
+++ b/binsync/ui/panel_tabs/activity_table.py
@@ -41,6 +41,8 @@ class ActivityTableModel(BinsyncTableModel):
             elif col == 2:
                 return friendly_datetime(self.row_data[row][col])
         elif role == self.SortRole:
+            if col == self.time_col and isinstance(self.row_data[row][col], datetime.datetime):
+                return time.mktime(self.row_data[row][col].timetuple())
             return self.row_data[row][col]
         elif role == Qt.BackgroundRole:
             return self.data_bgcolors[row]

--- a/binsync/ui/panel_tabs/ctx_table.py
+++ b/binsync/ui/panel_tabs/ctx_table.py
@@ -33,6 +33,8 @@ class CTXTableModel(BinsyncTableModel):
             elif col == 2:
                 return friendly_datetime(self.row_data[row][col])
         elif role == self.SortRole:
+            if col == self.time_col and isinstance(self.row_data[row][col], datetime.datetime):
+                return time.mktime(self.row_data[row][col].timetuple())
             return self.row_data[row][col]
         elif role == Qt.BackgroundRole:
             return self.data_bgcolors[row]

--- a/binsync/ui/panel_tabs/functions_table.py
+++ b/binsync/ui/panel_tabs/functions_table.py
@@ -42,6 +42,8 @@ class FunctionTableModel(BinsyncTableModel):
             elif col == 3:
                 return friendly_datetime(self.row_data[row][col])
         elif role == self.SortRole:
+            if col == self.time_col and isinstance(self.row_data[row][col], datetime.datetime):
+                return time.mktime(self.row_data[row][col].timetuple())
             return self.row_data[row][col]
         elif role == Qt.BackgroundRole:
             return self.data_bgcolors[row]

--- a/binsync/ui/panel_tabs/globals_table.py
+++ b/binsync/ui/panel_tabs/globals_table.py
@@ -38,6 +38,8 @@ class GlobalsTableModel(BinsyncTableModel):
             elif col == 3:
                 return friendly_datetime(self.row_data[row][col])
         elif role == self.SortRole:
+            if col == self.time_col and isinstance(self.row_data[row][col], datetime.datetime):
+                return time.mktime(self.row_data[row][col].timetuple())
             return self.row_data[row][col]
         elif role == Qt.BackgroundRole:
             return self.data_bgcolors[row]


### PR DESCRIPTION
Added a bit of extra logic to make sorting by last_push in the tables work. Shouldn't cause issues in rare cases where `time_col = None`.

Closes #277 