### PR TITLE
Fix MANIFEST.in broken with v4.0.0

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
 include LICENSE
 include README.md
-recursive-include binsync/decompiler_stubs *.json *.toml
-recursive-include binsync/decompilers *.png
+recursive-include binsync/stub_files *.png *.json *.toml


### PR DESCRIPTION
With e9f3a12fda8ea295d559f535c489796900f55f28, files were moved around but the MANIFEST.in was not updated to reflect these.
This results in errors in BinaryNinja and other tools:
![image](https://github.com/binsync/binsync/assets/11236933/d5dd8339-3fe1-431e-8f0b-aa50a32a5089)
