### PR TITLE
Remove remote_pdb import

### DIFF
--- a/binsync/interface_overrides/binja.py
+++ b/binsync/interface_overrides/binja.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 
-import remote_pdb
 from PySide6.QtGui import QImage
 from PySide6.QtWidgets import (
     QVBoxLayout


### PR DESCRIPTION
This import is unused, and is not part of the package's dependencies, so the plugin fails to load unless the package happens to be installed. I assume it is a remnant from remote_pdb usage during development.