### PR TITLE
Fix control panel action

### DIFF
--- a/binsync/interface_overrides/ida.py
+++ b/binsync/interface_overrides/ida.py
@@ -39,6 +39,10 @@ class AlwaysActiveAction(idaapi.action_handler_t):
         self.plugin = plugin
         self.typ = typ
 
+    def activate(self, ctx):
+        self.action()
+        return 1
+
     def update(self, ctx):
         return idaapi.AST_ENABLE_ALWAYS
 


### PR DESCRIPTION
![image](https://github.com/binsync/binsync/assets/76202024/c99348f8-7a61-478f-86d2-9857db7b8cc0)


The action to display the control panel when the menu button is pressed was not implemented within the AlwaysActiveAction class.