### PR TITLE
Fixes a race condition in get_state between controller.py and core/client.py

### DIFF
--- a/binsync/controller.py
+++ b/binsync/controller.py
@@ -794,7 +794,7 @@ class BSController:
             # no progress bar needed!
             _func_addrs = set(func_addrs)
             for addr, func in self.deci.functions.items():
-                if addr in func_addrs:
+                if addr in _func_addrs:
                     funcs.append(func)
 
         for func in funcs:

--- a/binsync/controller.py
+++ b/binsync/controller.py
@@ -769,6 +769,13 @@ class BSController:
         TODO: push the comments and custom types that are associated with each stack vars
         TODO: refactor to use internal push_function for correct commit message
         """
+
+        # NOTE: The following check allows to show a warning to a user and to
+        # avoid a ZeroDivisionError in the progress_bar declared later below
+        if not func_addrs:
+            _l.warning("Ignored force push, no function selected")
+            return
+
         master_state: State = self.client.master_state
         committed = 0
         progress_str = "Decompiling functions to push..." if use_decompilation else "Collecting functions..."

--- a/binsync/controller.py
+++ b/binsync/controller.py
@@ -772,7 +772,7 @@ class BSController:
         master_state: State = self.client.master_state
         committed = 0
         progress_str = "Decompiling functions to push..." if use_decompilation else "Collecting functions..."
-        change_time = int(time.time())
+        change_time = datetime.datetime.now(tz=datetime.timezone.utc)
 
         funcs = []
         if use_decompilation:

--- a/binsync/core/scheduler.py
+++ b/binsync/core/scheduler.py
@@ -95,3 +95,6 @@ class Scheduler:
 
         _l.debug("%s: completing scheduled job now: %s", self.name, job)
         job.execute()
+
+        if job.exception:
+            _l.exception("%s: exception in scheduled job %s: %s", self.name, job, job.exception)


### PR DESCRIPTION
There might be a race between `get_state(no_cache=True)` in `Client` and `get_state(...)` from `all_states()` in `Controller` which uses the `Cache`. That race happens when we have a repository with a lot of artifacts to retrieve from a user that is not the master user. As the `Cache` is using a `defaultdict()` we will get an empty state back when querying from the cache, and we always get this empty state as we don't update the cache. And it may stay for a while on `Loading...` state.