### PR TITLE
Removed useless `git fetch` before `git pull`

### DIFF
--- a/binsync/core/client.py
+++ b/binsync/core/client.py
@@ -459,7 +459,6 @@ class Client:
             try:
                 self._localize_remote_branches()
                 self.repo.git.checkout(BINSYNC_ROOT_BRANCH)
-                self.repo.git.fetch("--all")
                 self.repo.git.pull("--all")
                 self._last_pull_time = datetime.datetime.now(tz=datetime.timezone.utc)
                 self.active_remote = True


### PR DESCRIPTION
The `git pull` operation actually does `git fetch` + `git merge` operations under the hood, so performing `git fetch` before `git pull` was redundant. The `--all` option of `git pull` is actually internally forwarded to the `git fetch` command (see `man git pull`).