### PR TITLE
Use an alternate method to get the current bv

### DIFF
--- a/binsync/interface_overrides/binja.py
+++ b/binsync/interface_overrides/binja.py
@@ -80,7 +80,7 @@ class BinjaBSInterface(BinjaInterface):
             Sidebar.addSidebarWidgetType(self.sidebar_widget_type)
 
     def _launch_bs_config(self, bn_context):
-        bv = bn_context.binaryView
+        bv = bn_context.context.getCurrentView().getData()
         bs_controller = self.controllers[bv]
 
         # exit early if we already configured


### PR DESCRIPTION
If the focus is on the sidebar, then bn_context.binaryView is None. However, we can get the current view and then ask it for its data, which gives a valid binary view. I'm not entirely sure if this is the right way to get this information but it works for now and fixes a bug where you couldn't configure BinSync if the side panel was open.