### PR TITLE
Caching system to store computed diff

### DIFF
--- a/binsync/controller.py
+++ b/binsync/controller.py
@@ -195,6 +195,8 @@ class BSController:
         pass
 
     def shutdown(self):
+        if self.client and self.client.cache:
+            self.client.cache.clear_diffs()
         self.stop_worker_routines()
         self.deci.shutdown()
 
@@ -1432,6 +1434,15 @@ class BSController:
         on name, type, args, and comments for master and target functions which can then be parsed to see 
         how they differ. 
         """
+        # Check cache first
+        if self.client and self.client.cache:
+            cached_diff = self.client.cache.get_diff(func_addr, user)
+            if cached_diff is not None:
+                _l.info(f"[CACHE HIT] Retrieved diff from cache for func_addr={hex(func_addr) if func_addr else None}, user={user}")
+                return cached_diff
+
+        # Compute diff normally if no cache exists
+        _l.info(f"[CACHE MISS] Computing diff for func_addr={hex(func_addr) if func_addr else None}, user={user}")
         state = self.get_state(user=user, priority=SchedSpeed.FAST)
         user = user or state.user
         master_state = self.client.master_state
@@ -1467,6 +1478,10 @@ class BSController:
                 'target': target_comments
             }
         }
+
+        # Cache the diff
+        if self.client and self.client.cache:
+            self.client.cache.set_diff(func_addr, user, diffs)
 
         return diffs
             


### PR DESCRIPTION
There is now a caching system to store the computed diff whenever sync is hovered over. It will compute the sync diff whenever it's hovered for the first time, and store it in cache for future use. All cache is cleared on program shutdown in the shutdown function.