### PR TITLE
bump to version 5.15.1 to add IDA 9.3 support

### DIFF
--- a/binsync/__init__.py
+++ b/binsync/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "5.15.0"
+__version__ = "5.15.1"
 # don't forget to bump binsync/stub_files/plugin.json
 
 import os

--- a/binsync/stub_files/ida-plugin.json
+++ b/binsync/stub_files/ida-plugin.json
@@ -3,15 +3,15 @@
   "plugin": {
     "name": "BinSync",
     "entryPoint": "binsync_plugin.py",
-    "version": "5.15.0",
-    "idaVersions": ["8.4", "9.0","9.1", "9.2"],
+    "version": "5.15.1",
+    "idaVersions": ["8.4", "9.0","9.1", "9.2", "9.3"],
     "description": "A reversing plugin for cross-decompiler collaboration, built on git. Supports IDA, Ghidra, Binary Ninja, and angr-management!",
     "license": "BSD 2 Simplified",
     "categories": [
       "collaboration-and-productivity"
     ],
     "logoPath": "binsync.png",
-    "pythonDependencies": ["binsync==5.15.0"],
+    "pythonDependencies": ["binsync==5.15.1"],
     "urls": {
       "repository": "https://github.com/binsync/binsync"
     },

--- a/binsync/stub_files/plugin.json
+++ b/binsync/stub_files/plugin.json
@@ -15,7 +15,7 @@
 		"Linux" : "Install through the Binja Plugin Manager. To update do `pip install -U binsync`",
 		"Windows" : "Install through the Binja Plugin Manager. To update do `pip install -U binsync`"
 	},
-	"version": "5.15.0",
+	"version": "5.15.1",
 	"author": "BinSync Team",
 	"minimumbinaryninjaversion": 1200
 }

--- a/binsync/stub_files/requirements.txt
+++ b/binsync/stub_files/requirements.txt
@@ -1,1 +1,1 @@
-binsync>=5.15.0
+binsync>=5.15.1


### PR DESCRIPTION
Dear maintainers,

Inspired from https://github.com/binsync/binsync/commit/667ba599b79766339820f57dab8f8ce01b05808b 
I bump the version to support IDA Pro 9.3 which seems to work just fine on my end.
I also bump the version to 5.15.1, so that when setting a new version tag the CI will push new version on Pypi along with the IDA Pro plugin package.