### PR TITLE
Rename libbs dependency to declib

### DIFF
--- a/.github/workflows/core-tests.yml
+++ b/.github/workflows/core-tests.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install flake8 pytest
-        (git clone https://github.com/binsync/libbs.git /tmp/libbs && cd /tmp/libbs && git checkout $BRANCH_NAME || true && pip install .)
+        (git clone https://github.com/binsync/declib.git /tmp/declib && cd /tmp/declib && git checkout $BRANCH_NAME || true && pip install .)
         pip install .
     - name: Pytest
       run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,13 +18,13 @@ BinSync is a decompiler collaboration tool built on Git versioning that enables 
 
 ### Decompiler Integration
 
-- **Interface Overrides (`binsync/interface_overrides/`)**: Decompiler-specific implementations extending libbs DecompilerInterface
+- **Interface Overrides (`binsync/interface_overrides/`)**: Decompiler-specific implementations extending declib DecompilerInterface
 - **Plugin System**: Main plugin creation through `create_plugin()` in `__init__.py`
 - **UI Components (`binsync/ui/`)**: Cross-platform UI panels and dialogs
 
 ### Key Dependencies
 
-- **libbs**: Core binary analysis library for decompiler abstraction (>=2.15.6)
+- **declib**: Core binary analysis library for decompiler abstraction (>=4.0.1)
 - **GitPython**: Git operations and repository management
 - **PySide6**: GUI framework (for Ghidra support)
 
@@ -62,7 +62,7 @@ cd tests/
 ## Key Patterns
 
 ### Artifact Management
-- All artifacts inherit from libbs `Artifact` base class
+- All artifacts inherit from declib `Artifact` base class
 - State management uses TOML serialization with hex encoding for addresses
 - Branch-based isolation: each user gets their own Git branch (`binsync/username`)
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ To understand the difference between artifact support, pull, push, and auto push
 | Auto Push 	                        | :white_check_mark:                       | :white_check_mark:		               | :x:					                            | :x:					                        | :x: 					                     | :white_check_mark: 					         |
 
 ## Scripting
-For scripting please see [Lib BinSync](https://github.com/binsync/libbs), which allows you to do all lifting and data manipulation in Python.
+For scripting please see [DecLib](https://github.com/binsync/declib), which allows you to do all lifting and data manipulation in Python.
 
 ## Sponsors 
 BinSync and its associated projects would not be possible without sponsorship. 

--- a/binsync/__init__.py
+++ b/binsync/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "5.15.1"
+__version__ = "5.15.2"
 # don't forget to bump binsync/stub_files/plugin.json
 
 import os

--- a/binsync/__init__.py
+++ b/binsync/__init__.py
@@ -22,8 +22,8 @@ if platform.system() == "Darwin":
 
 
 def create_plugin(*args, **kwargs):
-    from libbs.api import DecompilerInterface
-    from libbs.decompilers import IDA_DECOMPILER, ANGR_DECOMPILER, BINJA_DECOMPILER, GHIDRA_DECOMPILER
+    from declib.api import DecompilerInterface
+    from declib.decompilers import IDA_DECOMPILER, ANGR_DECOMPILER, BINJA_DECOMPILER, GHIDRA_DECOMPILER
 
     # First discover the current decompiler and grab the overrides for BinSync specific UI
     current_decompiler = DecompilerInterface.find_current_decompiler()

--- a/binsync/__main__.py
+++ b/binsync/__main__.py
@@ -4,12 +4,12 @@ from pathlib import Path
 import os
 import sys
 
-from libbs.decompilers import SUPPORTED_DECOMPILERS, GHIDRA_DECOMPILER, ANGR_DECOMPILER, IDA_DECOMPILER, BINJA_DECOMPILER
+from declib.decompilers import SUPPORTED_DECOMPILERS, GHIDRA_DECOMPILER, ANGR_DECOMPILER, IDA_DECOMPILER, BINJA_DECOMPILER
 
 from binsync.installer import BinSyncInstaller
 from binsync.extras import EXTRAS_AVAILABLE
 import binsync
-import libbs
+import declib
 
 l = logging.getLogger(__name__)
 
@@ -64,7 +64,7 @@ def main():
         """
     )
     parser.add_argument(
-        "-v", "--version", action="version", version=f"BinSync {binsync.__version__} | LibBS {libbs.__version__}"
+        "-v", "--version", action="version", version=f"BinSync {binsync.__version__} | DecLib {declib.__version__}"
     )
     if EXTRAS_AVAILABLE:
         parser.add_argument(

--- a/binsync/binsync_plugin.py
+++ b/binsync/binsync_plugin.py
@@ -12,7 +12,7 @@ def create_plugin(*args, **kwargs):
     return _create_plugin(*args, **kwargs)
 
 # =============================================================================
-# LibBS generic plugin loader (don't touch things below this)
+# DecLib generic plugin loader (don't touch things below this)
 # =============================================================================
 
 

--- a/binsync/configuration.py
+++ b/binsync/configuration.py
@@ -5,7 +5,7 @@ import itertools
 from hashlib import md5
 from typing import Optional, Dict
 
-from libbs.configuration import BSConfig
+from declib.configuration import DLConfig
 
 l = logging.getLogger(__name__)
 max_recent_projects = 5
@@ -48,8 +48,8 @@ class ProjectData:
         return proj_data
 
 
-class BinSyncBSConfig(BSConfig):
-    __slots__ = BSConfig.__slots__ + (
+class BinSyncDLConfig(DLConfig):
+    __slots__ = DLConfig.__slots__ + (
         "recent_projects",
         "table_coloring_window",
         "log_level",

--- a/binsync/controller.py
+++ b/binsync/controller.py
@@ -8,24 +8,24 @@ from typing import Dict, Iterable, Optional, Union, List, Tuple
 import math
 import re
 
-from libbs.api.utils import progress_bar
-from libbs.artifacts import (
+from declib.api.utils import progress_bar
+from declib.artifacts import (
     Artifact,
     Function, FunctionHeader, StackVariable,
     Comment, GlobalVariable, Patch,
     Enum, Struct, FunctionArgument, StructMember, Typedef, Segment, Context, Decompilation
 )
-from libbs.api import DecompilerInterface
-from libbs.api.type_parser import CType
+from declib.api import DecompilerInterface
+from declib.api.type_parser import CType
 
 from binsync.core.client import Client, SchedSpeed, Scheduler, Job
 from binsync.core.state import State
 from binsync.core.user import User
-from binsync.configuration import BinSyncBSConfig
+from binsync.configuration import BinSyncDLConfig
 
 from wordfreq import word_frequency
 
-from libbs.decompilers import IDA_DECOMPILER
+from declib.decompilers import IDA_DECOMPILER
 
 _l = logging.getLogger(name=__name__)
 
@@ -252,7 +252,7 @@ class BSController:
         except RuntimeError:
             pass
 
-        from libbs.ui.qt_objects import (
+        from declib.ui.qt_objects import (
             QThread
         )
         from binsync.ui.utils import BSUIScheduler
@@ -726,7 +726,7 @@ class BSController:
                 # set the imports into the decompiler
                 art_dict[identifier] = merged_artifact
 
-                # TODO: figure out a way to do this inside LibBS (getting all comments for a func)
+                # TODO: figure out a way to do this inside DecLib (getting all comments for a func)
                 if artifact_type is Function:
                     for addr, cmt in state.get_func_comments(merged_artifact.addr).items():
                         self.fill_artifact(addr, artifact_type=Comment, artifact=cmt, state=state, user=user)
@@ -1463,8 +1463,8 @@ class BSController:
     # Config Utils
     #
 
-    def load_saved_config(self) -> Optional[BinSyncBSConfig]:
-        config = BinSyncBSConfig().load_from_file()
+    def load_saved_config(self) -> Optional[BinSyncDLConfig]:
+        config = BinSyncDLConfig().load_from_file()
         if not config:
             return None
 

--- a/binsync/core/client.py
+++ b/binsync/core/client.py
@@ -15,7 +15,7 @@ import git
 import git.exc
 
 from binsync.core.user import User
-from binsync.configuration import BinSyncBSConfig, ProjectData
+from binsync.configuration import BinSyncDLConfig, ProjectData
 from binsync.core.errors import ExternalUserCommitError, MetadataNotFoundError
 from binsync.core.state import State, toml_file_to_dict
 from binsync.core.scheduler import Scheduler, Job, SchedSpeed

--- a/binsync/core/state.py
+++ b/binsync/core/state.py
@@ -11,7 +11,7 @@ import toml
 from sortedcontainers import SortedDict
 
 
-from libbs.artifacts import (
+from declib.artifacts import (
     Artifact,
     ArtifactFormat,
     Comment,
@@ -23,7 +23,7 @@ from libbs.artifacts import (
     StackVariable,
     Struct, Typedef, Segment,
 )
-from libbs.artifacts import TomlHexEncoder
+from declib.artifacts import TomlHexEncoder
 from binsync import __version__ as BS_VERS
 from binsync.core.errors import MetadataNotFoundError
 
@@ -386,7 +386,7 @@ class State:
         impacting the DecompilerInterface as everything 
         is deepcopy'ed.
 
-        @param deci: A libbs.DecompilerInterface object
+        @param deci: A declib.DecompilerInterface object
         """
         state = cls(None)
 

--- a/binsync/extras/aux_server/aux_client.py
+++ b/binsync/extras/aux_server/aux_client.py
@@ -2,7 +2,7 @@ import urllib.parse
 import requests
 import logging
 import time
-from libbs.artifacts import (
+from declib.artifacts import (
     Context
 )
 l = logging.getLogger(__name__)

--- a/binsync/installer.py
+++ b/binsync/installer.py
@@ -2,10 +2,10 @@ import shutil
 import textwrap
 from pathlib import Path
 
-from libbs.plugin_installer import LibBSPluginInstaller, PluginInstaller
+from declib.plugin_installer import DecLibPluginInstaller, PluginInstaller
 
 
-class BinSyncInstaller(LibBSPluginInstaller):
+class BinSyncInstaller(DecLibPluginInstaller):
     def __init__(self):
         super().__init__(targets=PluginInstaller.DECOMPILERS)
         pkg_files = self.find_pkg_files("binsync")

--- a/binsync/interface_overrides/angr.py
+++ b/binsync/interface_overrides/angr.py
@@ -2,11 +2,11 @@ import logging
 import typing
 
 # pylint: disable=wrong-import-position,wrong-import-order
-from libbs.ui.version import set_ui_version
+from declib.ui.version import set_ui_version
 set_ui_version("PySide6")
 
-from libbs.ui.qt_objects import QVBoxLayout
-from libbs.decompilers.angr.compat import GenericBSAngrManagementPlugin
+from declib.ui.qt_objects import QVBoxLayout
+from declib.decompilers.angr.compat import GenericDLAngrManagementPlugin
 
 from angrmanagement.ui.views.view import BaseView
 from PySide6QtAds import SideBarRight, CDockWidget, CDockManager
@@ -52,7 +52,7 @@ class ControlPanelView(BaseView):
         self.setLayout(main_layout)
 
 
-class BinsyncPlugin(GenericBSAngrManagementPlugin):
+class BinsyncPlugin(GenericDLAngrManagementPlugin):
     """
     Controller plugin for BinSync
     """

--- a/binsync/interface_overrides/binja.py
+++ b/binsync/interface_overrides/binja.py
@@ -14,8 +14,8 @@ from binaryninjaui import (
     Sidebar,
 )
 
-from libbs.plugin_installer import PluginInstaller
-from libbs.decompilers.binja.interface import BinjaInterface
+from declib.plugin_installer import PluginInstaller
+from declib.decompilers.binja.interface import BinjaInterface
 
 from binsync.controller import BSController
 from binsync.ui.control_panel import ControlPanel

--- a/binsync/interface_overrides/ghidra.py
+++ b/binsync/interface_overrides/ghidra.py
@@ -4,11 +4,11 @@ import threading
 from time import sleep
 import subprocess
 
-from libbs.ui.version import set_ui_version
+from declib.ui.version import set_ui_version
 set_ui_version("PySide6")
-from libbs.ui.qt_objects import QMainWindow, QApplication, QTimer
-from libbs.api import DecompilerInterface
-from libbs.api.decompiler_server import DecompilerServer
+from declib.ui.qt_objects import QMainWindow, QApplication, QTimer
+from declib.api import DecompilerInterface
+from declib.api.decompiler_server import DecompilerServer
 
 from binsync.ui.control_panel import ControlPanel
 from binsync.ui.config_dialog import ConfigureBSDialog
@@ -54,7 +54,7 @@ class ControlPanelWindow(QMainWindow):
 
 
 def start_ghidra_ui():
-    from libbs.api.decompiler_client import DecompilerClient
+    from declib.api.decompiler_client import DecompilerClient
     deci = DecompilerClient.discover()
     app = QApplication.instance()
     if app is None:

--- a/binsync/interface_overrides/ida.py
+++ b/binsync/interface_overrides/ida.py
@@ -5,13 +5,13 @@ import ida_kernwin
 import ida_hexrays
 import idautils
 
-from libbs.decompilers.ida.compat import get_ida_gui_version
-from libbs.ui.version import set_ui_version
+from declib.decompilers.ida.compat import get_ida_gui_version
+from declib.ui.version import set_ui_version
 set_ui_version(get_ida_gui_version())
-from libbs.ui.qt_objects import QEvent, Qt, QKeyEvent, QWidget, QVBoxLayout, wrapInstance
-from libbs.decompilers.ida.compat import has_older_hexrays_version, generate_generic_ida_plugic_cls
-from libbs.decompilers.ida.ida_ui import IDAWidgetWrapper
-from libbs.decompilers.ida.interface import IDAInterface
+from declib.ui.qt_objects import QEvent, Qt, QKeyEvent, QWidget, QVBoxLayout, wrapInstance
+from declib.decompilers.ida.compat import has_older_hexrays_version, generate_generic_ida_plugic_cls
+from declib.decompilers.ida.ida_ui import IDAWidgetWrapper
+from declib.decompilers.ida.interface import IDAInterface
 
 from binsync.ui.config_dialog import ConfigureBSDialog
 from binsync.ui.control_panel import ControlPanel

--- a/binsync/stub_files/ida-plugin.json
+++ b/binsync/stub_files/ida-plugin.json
@@ -3,7 +3,7 @@
   "plugin": {
     "name": "BinSync",
     "entryPoint": "binsync_plugin.py",
-    "version": "5.15.1",
+    "version": "5.15.2",
     "idaVersions": ["8.4", "9.0","9.1", "9.2", "9.3"],
     "description": "A reversing plugin for cross-decompiler collaboration, built on git. Supports IDA, Ghidra, Binary Ninja, and angr-management!",
     "license": "BSD 2 Simplified",
@@ -11,7 +11,7 @@
       "collaboration-and-productivity"
     ],
     "logoPath": "binsync.png",
-    "pythonDependencies": ["binsync==5.15.1"],
+    "pythonDependencies": ["binsync==5.15.2"],
     "urls": {
       "repository": "https://github.com/binsync/binsync"
     },

--- a/binsync/stub_files/plugin.json
+++ b/binsync/stub_files/plugin.json
@@ -15,7 +15,7 @@
 		"Linux" : "Install through the Binja Plugin Manager. To update do `pip install -U binsync`",
 		"Windows" : "Install through the Binja Plugin Manager. To update do `pip install -U binsync`"
 	},
-	"version": "5.15.1",
+	"version": "5.15.2",
 	"author": "BinSync Team",
 	"minimumbinaryninjaversion": 1200
 }

--- a/binsync/stub_files/requirements.txt
+++ b/binsync/stub_files/requirements.txt
@@ -1,1 +1,1 @@
-binsync>=5.15.1
+binsync>=5.15.2

--- a/binsync/ui/aux_server_panel/aux_server_window.py
+++ b/binsync/ui/aux_server_panel/aux_server_window.py
@@ -5,7 +5,7 @@ import logging
 
 from binsync.ui.aux_server_panel.connected_window import AuxServerConnectedWidget
 from binsync.ui.aux_server_panel.disconnected_window import AuxServerDisconnectedWidget
-from libbs.ui.qt_objects import (
+from declib.ui.qt_objects import (
     QHBoxLayout,
     QLabel,
     QPushButton,

--- a/binsync/ui/aux_server_panel/connected_window.py
+++ b/binsync/ui/aux_server_panel/connected_window.py
@@ -1,5 +1,5 @@
 import logging
-from libbs.ui.qt_objects import (
+from declib.ui.qt_objects import (
     QHBoxLayout,
     QLabel,
     QPushButton,

--- a/binsync/ui/aux_server_panel/disconnected_window.py
+++ b/binsync/ui/aux_server_panel/disconnected_window.py
@@ -1,5 +1,5 @@
 import logging
-from libbs.ui.qt_objects import (
+from declib.ui.qt_objects import (
     QFormLayout,
     QVBoxLayout,
     QWidget,

--- a/binsync/ui/config_dialog.py
+++ b/binsync/ui/config_dialog.py
@@ -8,8 +8,8 @@ from typing import Optional
 import filelock
 
 from binsync.core.client import ConnectionWarnings, BINSYNC_ROOT_BRANCH
-from binsync.configuration import BinSyncBSConfig, ProjectData
-from libbs.ui.qt_objects import (
+from binsync.configuration import BinSyncDLConfig, ProjectData
+from declib.ui.qt_objects import (
     QCheckBox,
     QDialog,
     QDir,
@@ -555,7 +555,7 @@ class ConfigureBSDialog(QDialog):
     def load_saved_config(self):
         binary_hash = self.controller.deci.binary_hash
         config = self.controller.load_saved_config()
-        if not config or not isinstance(config, BinSyncBSConfig):
+        if not config or not isinstance(config, BinSyncDLConfig):
             return None
 
         if binary_hash not in config.recent_projects.keys():
@@ -585,7 +585,7 @@ class ConfigureBSDialog(QDialog):
             repo = str(Path(self.controller.client.repo_root).absolute())
 
         if not self.controller.config:
-            self.controller.config = BinSyncBSConfig()
+            self.controller.config = BinSyncDLConfig()
 
         self.controller.config.save_project_data(
             self.controller.deci.binary_path,

--- a/binsync/ui/control_panel.py
+++ b/binsync/ui/control_panel.py
@@ -1,13 +1,13 @@
 import logging
 
-import libbs.artifacts
+import declib.artifacts
 from binsync.ui.panel_tabs.activity_table import QActivityTable
 from binsync.ui.panel_tabs.ctx_table import QCTXTable
 from binsync.ui.panel_tabs.functions_table import QFunctionTable
 from binsync.ui.panel_tabs.globals_table import QGlobalsTable
 from binsync.ui.panel_tabs.types_table import QTypesTable
 from binsync.ui.panel_tabs.util_panel import QUtilPanel
-from libbs.ui.qt_objects import (
+from declib.ui.qt_objects import (
     QLabel,
     QMenu,
     QSplitter,
@@ -82,7 +82,7 @@ class ControlPanel(QWidget):
         self.update_ready.emit(status)
 
     def ctx_callback(self, states):
-        if isinstance(self.controller.last_active_func, libbs.artifacts.Function):
+        if isinstance(self.controller.last_active_func, declib.artifacts.Function):
             self._ctx_table.update_table(states, new_ctx=self.controller.last_active_func.addr)
 
         self.ctx_change.emit()

--- a/binsync/ui/force_push/force_push.py
+++ b/binsync/ui/force_push/force_push.py
@@ -4,8 +4,8 @@ from binsync.ui.force_push.panels.functions_table import QFunctionTable
 from binsync.ui.force_push.panels.globals_table import QGlobalsTable
 from binsync.ui.force_push.panels.types_table import QTypesTable
 from binsync.ui.force_push.panels.segments_table import QSegmentTable
-from libbs.api.utils import progress_bar
-from libbs.ui.qt_objects import (
+from declib.api.utils import progress_bar
+from declib.ui.qt_objects import (
     QDialog,
     QTabWidget,
     QVBoxLayout,

--- a/binsync/ui/force_push/panels/functions_table.py
+++ b/binsync/ui/force_push/panels/functions_table.py
@@ -4,7 +4,7 @@ from typing import Dict, Set
 
 from binsync.controller import BSController
 from binsync.ui.panel_tabs.table_model import BinsyncTableModel, BinsyncTableFilterLineEdit, BinsyncTableView
-from libbs.ui.qt_objects import (
+from declib.ui.qt_objects import (
     QWidget,
     QVBoxLayout,
     Qt,

--- a/binsync/ui/force_push/panels/globals_table.py
+++ b/binsync/ui/force_push/panels/globals_table.py
@@ -4,7 +4,7 @@ from typing import Dict, Set
 
 from binsync.controller import BSController
 from binsync.ui.panel_tabs.table_model import BinsyncTableModel, BinsyncTableFilterLineEdit, BinsyncTableView
-from libbs.ui.qt_objects import (
+from declib.ui.qt_objects import (
     QWidget,
     QVBoxLayout,
     Qt,

--- a/binsync/ui/force_push/panels/segments_table.py
+++ b/binsync/ui/force_push/panels/segments_table.py
@@ -4,7 +4,7 @@ from typing import Dict, Set
 
 from binsync.controller import BSController
 from binsync.ui.panel_tabs.table_model import BinsyncTableModel, BinsyncTableFilterLineEdit, BinsyncTableView
-from libbs.ui.qt_objects import (
+from declib.ui.qt_objects import (
     QWidget,
     QVBoxLayout,
     Qt,

--- a/binsync/ui/force_push/panels/table_model.py
+++ b/binsync/ui/force_push/panels/table_model.py
@@ -3,7 +3,7 @@ import datetime
 from typing import Dict, Set
 
 from binsync.controller import BSController
-from libbs.ui.qt_objects import (
+from declib.ui.qt_objects import (
     QAbstractItemView,
     QAbstractTableModel,
     QHeaderView,

--- a/binsync/ui/force_push/panels/types_table.py
+++ b/binsync/ui/force_push/panels/types_table.py
@@ -4,7 +4,7 @@ from typing import Dict, Set
 
 from binsync.controller import BSController
 from binsync.ui.panel_tabs.table_model import BinsyncTableModel, BinsyncTableFilterLineEdit, BinsyncTableView
-from libbs.ui.qt_objects import (
+from declib.ui.qt_objects import (
     QWidget,
     QVBoxLayout,
     Qt,

--- a/binsync/ui/function_merge_dialog.py
+++ b/binsync/ui/function_merge_dialog.py
@@ -1,6 +1,6 @@
 import logging
 
-from libbs.ui.qt_objects import (
+from declib.ui.qt_objects import (
     QDialog,
     QDialogButtonBox,
     QGridLayout,

--- a/binsync/ui/history_display/history_window.py
+++ b/binsync/ui/history_display/history_window.py
@@ -4,7 +4,7 @@ from binsync.controller import BSController
 from datetime import datetime, timezone, timedelta
 from binsync.ui.panel_tabs.table_model import BinsyncTableModel, BinsyncTableView
 from binsync.core.client import SchedSpeed
-from libbs.ui.qt_objects import (
+from declib.ui.qt_objects import (
     # QtWidgets
     QDialog,
     QHBoxLayout,

--- a/binsync/ui/magic_sync_dialog.py
+++ b/binsync/ui/magic_sync_dialog.py
@@ -1,6 +1,6 @@
 import logging
 
-from libbs.ui.qt_objects import (
+from declib.ui.qt_objects import (
     QDialog,
     QDialogButtonBox,
     QGridLayout,

--- a/binsync/ui/panel_tabs/activity_table.py
+++ b/binsync/ui/panel_tabs/activity_table.py
@@ -6,7 +6,7 @@ import time
 
 from binsync.controller import BSController
 from binsync.ui.panel_tabs.table_model import BinsyncTableModel, BinsyncTableFilterLineEdit, BinsyncTableView
-from libbs.ui.qt_objects import (
+from declib.ui.qt_objects import (
     QMenu,
     QAction,
     QWidget,
@@ -15,7 +15,7 @@ from libbs.ui.qt_objects import (
 )
 from binsync.ui.utils import friendly_datetime
 from binsync.core.scheduler import SchedSpeed
-from libbs.artifacts import Function
+from declib.artifacts import Function
 
 l = logging.getLogger(__name__)
 

--- a/binsync/ui/panel_tabs/ctx_table.py
+++ b/binsync/ui/panel_tabs/ctx_table.py
@@ -2,11 +2,11 @@ import logging
 import datetime
 import time
 
-from libbs.artifacts import Function
+from declib.artifacts import Function
 
 from binsync.controller import BSController
 from binsync.ui.panel_tabs.table_model import BinsyncTableModel, BinsyncTableView
-from libbs.ui.qt_objects import (
+from declib.ui.qt_objects import (
     QMenu,
     QAction,
     Qt

--- a/binsync/ui/panel_tabs/functions_table.py
+++ b/binsync/ui/panel_tabs/functions_table.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 
 from binsync.controller import BSController
 from binsync.ui.panel_tabs.table_model import BinsyncTableModel, BinsyncTableFilterLineEdit, BinsyncTableView
-from libbs.ui.qt_objects import (
+from declib.ui.qt_objects import (
     QMenu,
     QAction,
     QWidget,
@@ -17,7 +17,7 @@ from libbs.ui.qt_objects import (
 from binsync.ui.utils import friendly_datetime
 from binsync.core.scheduler import SchedSpeed
 from binsync.ui.history_display.history_window import HistoryDisplayWidget
-from libbs.artifacts import Function
+from declib.artifacts import Function
 
 l = logging.getLogger(__name__)
 

--- a/binsync/ui/panel_tabs/globals_table.py
+++ b/binsync/ui/panel_tabs/globals_table.py
@@ -3,11 +3,11 @@ import datetime
 from collections import defaultdict
 import time
 
-from libbs.artifacts import GlobalVariable
+from declib.artifacts import GlobalVariable
 
 from binsync.controller import BSController
 from binsync.ui.panel_tabs.table_model import BinsyncTableModel, BinsyncTableFilterLineEdit, BinsyncTableView
-from libbs.ui.qt_objects import (
+from declib.ui.qt_objects import (
     QMenu,
     QAction,
     QWidget,

--- a/binsync/ui/panel_tabs/table_model.py
+++ b/binsync/ui/panel_tabs/table_model.py
@@ -3,7 +3,7 @@ import datetime
 from typing import Any, Dict, Set
 
 from binsync.controller import BSController
-from libbs.ui.qt_objects import (
+from declib.ui.qt_objects import (
     QAbstractItemView,
     QAbstractTableModel,
     QEvent,

--- a/binsync/ui/panel_tabs/types_table.py
+++ b/binsync/ui/panel_tabs/types_table.py
@@ -3,11 +3,11 @@ import datetime
 from collections import defaultdict
 import time
 
-from libbs.artifacts import Struct, Enum, Typedef
+from declib.artifacts import Struct, Enum, Typedef
 
 from binsync.controller import BSController
 from binsync.ui.panel_tabs.table_model import BinsyncTableModel, BinsyncTableFilterLineEdit, BinsyncTableView
-from libbs.ui.qt_objects import (
+from declib.ui.qt_objects import (
     QMenu,
     QAction,
     QWidget,

--- a/binsync/ui/panel_tabs/util_panel.py
+++ b/binsync/ui/panel_tabs/util_panel.py
@@ -4,7 +4,7 @@ import requests
 import urllib.parse
 
 from binsync.controller import  MergeLevel
-from libbs.ui.qt_objects import (
+from declib.ui.qt_objects import (
     QCheckBox,
     QComboBox,
     QGroupBox,
@@ -25,7 +25,7 @@ from libbs.ui.qt_objects import (
     QTimer,
     Slot
 )
-from libbs.artifacts import (
+from declib.artifacts import (
     Context
 )
 from binsync.ui.magic_sync_dialog import MagicSyncDialog

--- a/binsync/ui/progress_graph/progress_window.py
+++ b/binsync/ui/progress_graph/progress_window.py
@@ -5,7 +5,7 @@ import os
 import networkx as nx
 import numpy as np
 
-from libbs.ui.qt_objects import (
+from declib.ui.qt_objects import (
     # QtWidgets
     QGraphicsScene,
     QGraphicsView,
@@ -29,8 +29,8 @@ from libbs.ui.qt_objects import (
     # QtCore
     Qt, QLineF, QTimer
 )
-from libbs.artifacts import Function
-from libbs.api.decompiler_interface import DecompilerInterface
+from declib.artifacts import Function
+from declib.api.decompiler_interface import DecompilerInterface
 from binsync.extras import EXTRAS_AVAILABLE
 
 from .summarize import summarize_changes

--- a/binsync/ui/pull_segments_dialog.py
+++ b/binsync/ui/pull_segments_dialog.py
@@ -1,7 +1,7 @@
 import logging
 
 from binsync.core.scheduler import SchedSpeed
-from libbs.ui.qt_objects import (
+from declib.ui.qt_objects import (
     QDialog,
     QDialogButtonBox,
     QGridLayout,

--- a/binsync/ui/utils.py
+++ b/binsync/ui/utils.py
@@ -2,7 +2,7 @@ import datetime
 import logging
 import threading
 
-from libbs.ui.qt_objects import (
+from declib.ui.qt_objects import (
     QFrame,
     QWidget,
     QScrollArea,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ description = "A Collaboration framework for binary analysis tasks."
 urls = {Homepage = "https://github.com/binsync/binsync"}
 requires-python = ">= 3.10"
 dependencies = [
-    "libbs[ghidra]>=3.4.1",
+    "declib[ghidra]>=4.0.1",
     "sortedcontainers",
     "toml",
     "GitPython",

--- a/tests/ci/setup_gui_ci.sh
+++ b/tests/ci/setup_gui_ci.sh
@@ -8,8 +8,8 @@ sudo apt-get update && sudo apt-get install -y \
   --exec /usr/bin/Xvfb -- :99 -screen 0 1920x1200x24 -ac +extension GLX
 # update pip
 python -m pip install --upgrade pip
-# install the parallel branch of libbs that matches the current branch
-(git clone https://github.com/binsync/libbs.git /tmp/libbs && cd /tmp/libbs && git checkout $BRANCH_NAME || true && pip install .)
+# install the parallel branch of declib that matches the current branch
+(git clone https://github.com/binsync/declib.git /tmp/declib && cd /tmp/declib && git checkout $BRANCH_NAME || true && pip install .)
 # attempt an install of angr-management first since version of binsync will conflict
 pip install angr-management==9.2.139
 pip install .[test]

--- a/tests/test_angr_gui.py
+++ b/tests/test_angr_gui.py
@@ -18,7 +18,7 @@ import angr
 from angrmanagement.ui.dialogs.rename_node import RenameNode
 from angrmanagement.ui.main_window import MainWindow
 
-from libbs.ui.version import set_ui_version
+from declib.ui.version import set_ui_version
 set_ui_version("PySide6")
 from binsync.controller import SyncControlStatus
 from binsync.ui.config_dialog import ConfigureBSDialog

--- a/tests/test_auxiliary_server.py
+++ b/tests/test_auxiliary_server.py
@@ -4,7 +4,7 @@ from binsync.extras.aux_server.aux_server import Server
 from binsync.extras.aux_server.store import ServerStore
 
 from binsync.ui.aux_server_panel.aux_server_window import ClientWorker
-from libbs.ui.qt_objects import (
+from declib.ui.qt_objects import (
     QThread,
     QWidget,
     Signal,
@@ -17,7 +17,7 @@ import time
 import socket
 from werkzeug.serving import make_server
 from contextlib import contextmanager
-from libbs.artifacts import Artifact, Context
+from declib.artifacts import Artifact, Context
 
 
 class MockContext:
@@ -276,8 +276,8 @@ class TestAuxServer(unittest.TestCase):
         binsync_url = "https://github.com/binsync/binsync.git"
         binsync_group_name = "binsync"
         
-        libbs_url = "https://github.com/binsync/libbs.git"
-        libbs_group_name = "libbs"
+        declib_url = "https://github.com/binsync/declib.git"
+        declib_group_name = "declib"
         self.server_thread_manager = ServerThreadManager(server)
         self.server_thread_manager.enter()
         
@@ -289,11 +289,11 @@ class TestAuxServer(unittest.TestCase):
         
         # Client makes new groups
         user.add_group.emit(binsync_group_name)
-        user.add_group.emit(libbs_group_name)
+        user.add_group.emit(declib_group_name)
         
         # Client links projects
         user.link_project.emit((binsync_url, binsync_group_name))
-        user.link_project.emit((libbs_url, libbs_group_name))
+        user.link_project.emit((declib_url, declib_group_name))
         
         # Validate projects list contains only our one project
         user.list_projects.emit()
@@ -304,8 +304,8 @@ class TestAuxServer(unittest.TestCase):
             binsync_group_name: {
                 binsync_url: None
             },
-            libbs_group_name: {
-                libbs_url: None
+            declib_group_name: {
+                declib_url: None
             }
         }
 
@@ -313,7 +313,7 @@ class TestAuxServer(unittest.TestCase):
         user.delete_group.emit(binsync_group_name)
         
         # Client unlinks a project 
-        user.unlink_project.emit((libbs_url, libbs_group_name))
+        user.unlink_project.emit((declib_url, declib_group_name))
         
         # Validate projects list is empty
         user.list_projects.emit()
@@ -321,7 +321,7 @@ class TestAuxServer(unittest.TestCase):
         self.app.processEvents()
         assert user.linked_projects == {
             ServerStore.DEFAULT_GROUPNAME: {},
-            libbs_group_name: {}
+            declib_group_name: {}
         }
     
     def test_multi_user_link_unlink_projects(self):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -7,7 +7,7 @@ import toml
 
 import unittest
 
-from libbs.artifacts import (
+from declib.artifacts import (
     FunctionHeader, StackVariable, Comment, Struct
 )
 from binsync.core.client import Client

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -5,7 +5,7 @@ import sys
 import unittest
 
 from binsync.core.client import Client
-from libbs.artifacts import (
+from declib.artifacts import (
     FunctionHeader, Struct, StructMember,
 )
 from binsync.core.state import State, ArtifactType


### PR DESCRIPTION
libbs was renamed upstream to declib (4.x). Update all imports, renamed symbols, CI installs, and docs accordingly:

- libbs.* -> declib.* imports across all modules and tests
- BSConfig -> DLConfig (and BinSyncBSConfig -> BinSyncDLConfig)
- LibBSPluginInstaller -> DecLibPluginInstaller
- GenericBSAngrManagementPlugin -> GenericDLAngrManagementPlugin
- pyproject: declib[ghidra]>=4.0.1
- CI: clone binsync/declib.git in core-tests.yml and setup_gui_ci.sh
- README/CLAUDE.md links and version notes