### PR TITLE
Fix force-push and sync dispatch, harden decompiler UI lifecycles

### DIFF
--- a/.github/workflows/core-tests.yml
+++ b/.github/workflows/core-tests.yml
@@ -30,4 +30,4 @@ jobs:
         pip install .
     - name: Pytest
       run: |
-        pytest ./tests/test_client.py ./tests/test_state.py
+        pytest ./tests/test_client.py ./tests/test_state.py ./tests/test_controller.py

--- a/.github/workflows/gui-tests.yml
+++ b/.github/workflows/gui-tests.yml
@@ -25,4 +25,4 @@ jobs:
 
     - name: Pytest
       run: |
-        QT_QPA_PLATFORM="offscreen" pytest ./tests/test_auxiliary_server.py -s #./tests/test_angr_gui.py
+        QT_QPA_PLATFORM="offscreen" pytest ./tests/test_auxiliary_server.py ./tests/test_binja.py ./tests/test_ghidra.py ./tests/test_ui_panels.py -s #./tests/test_angr_gui.py

--- a/binsync/controller.py
+++ b/binsync/controller.py
@@ -277,9 +277,6 @@ class BSController:
             self._ui_updater_thread.wait(2000)
 
     def schedule_job(self, cmd_func, *args, blocking=False, **kwargs):
-        if not self._auto_commit_enabled:
-            return None
-
         if blocking:
             return self.push_job_scheduler.schedule_and_wait_job(
                 Job(cmd_func, *args, **kwargs),
@@ -723,8 +720,15 @@ class BSController:
                             merged_artifact.header.args = {}
                             merged_artifact.header.type = None
 
-                # set the imports into the decompiler
-                art_dict[identifier] = merged_artifact
+                # set the imports into the decompiler. NOTE: a no-op set (e.g. the
+                # function already has this name/header in the decompiler) makes the
+                # underlying set_artifact return False, which the remote client turns
+                # into a "Failed to set artifact" exception. That must not abort the
+                # address-keyed comment sync below, so isolate the function set.
+                try:
+                    art_dict[identifier] = merged_artifact
+                except Exception as e:
+                    _l.warning("Setting %s into the decompiler made no change or failed: %s", merged_artifact, e)
 
                 # TODO: figure out a way to do this inside DecLib (getting all comments for a func)
                 if artifact_type is Function:
@@ -1124,13 +1128,17 @@ class BSController:
     # Force Push
     #
 
+    def _flush_force_push_state(self):
+        self.client.commit_and_update_states()
+
     @init_checker
     def force_push_functions(self, func_addrs: List[int], use_decompilation=False):
         """
         Collects the functions currently stored in the decompiler, not the BS State, and commits it to
-        the master users BS Database. Function addrs should be in the lifted form.
+        the master users BS Database. Function addrs should be in the lifted form. Comments that fall
+        within each pushed function are collected from the decompiler and committed as well.
 
-        TODO: push the comments and custom types that are associated with each stack vars
+        TODO: push the custom types that are associated with each stack var
         TODO: refactor to use internal push_function for correct commit message
         """
 
@@ -1164,10 +1172,60 @@ class BSController:
             master_state.set_function(func)
         committed += len(funcs)
 
+        # also force push the comments contained within each pushed function. comments are a
+        # separate, address-keyed artifact rather than fields on the Function, so they are not
+        # carried by set_function and must be collected and committed explicitly.
+        cmt_committed = self._force_push_function_comments(master_state, funcs)
+
         # commit the master state back!
-        master_state.last_commit_msg = f"Force pushed {committed} functions"
+        cmt_suffix = f" and {cmt_committed} comment{'' if cmt_committed == 1 else 's'}" if cmt_committed else ""
+        master_state.last_commit_msg = f"Force pushed {committed} functions{cmt_suffix}"
         self.client.master_state = master_state
-        self.deci.info(f"Functions force push successful: committed {committed} function{'' if committed == 1 else 's'}.")
+        self._flush_force_push_state()
+        self.deci.info(
+            f"Functions force push successful: committed {committed} function{'' if committed == 1 else 's'}"
+            f"{cmt_suffix}."
+        )
+
+    def _force_push_function_comments(self, master_state: State, funcs: List[Function]) -> int:
+        """
+        Collects every comment currently set in the decompiler that falls within one of the given
+        functions and commits it into ``master_state``. The decompiler is scanned exactly once
+        regardless of how many functions are pushed. Comments are attributed to a function by
+        address range, matching ``State.get_func_comments``, so this works against any declib that
+        exposes ``deci.comments`` (it does not rely on the comment's ``func_addr`` being populated).
+        Returns the number of comments committed.
+        """
+        try:
+            decompiler_comments = dict(self.deci.comments.items())
+        except Exception as e:
+            _l.warning("Failed to collect decompiler comments for force push: %s", e)
+            return 0
+
+        if not decompiler_comments:
+            return 0
+
+        committed = 0
+        for func in funcs:
+            func_size = func.size or self.deci.get_func_size(func.addr) or 0
+            func_end = func.addr + func_size
+            for addr, cmt in decompiler_comments.items():
+                # libbs may hand back either a Comment artifact or a raw comment
+                # string depending on how the comment was set in the decompiler
+                # (e.g. programmatic/MCP edits arrive as plain strings); normalize
+                # to a Comment so the attribute access below is always valid.
+                if isinstance(cmt, str):
+                    cmt = Comment(addr=addr, comment=cmt)
+                if cmt is None or not cmt.comment:
+                    continue
+                if not (func.addr <= addr <= func_end):
+                    continue
+
+                cmt.func_addr = func.addr
+                if master_state.set_comment(cmt):
+                    committed += 1
+
+        return committed
 
     @init_checker
     def force_push_global_vars(self, addrs: List[int]):
@@ -1191,6 +1249,7 @@ class BSController:
 
         master_state.last_commit_msg = f"Force pushed {committed} global{'' if committed == 1 else 's'}"
         self.client.master_state = master_state
+        self._flush_force_push_state()
         self.deci.info(f"Globals force push successful: committed {committed} global{'' if committed == 1 else 's'}.")
 
     @init_checker
@@ -1218,6 +1277,7 @@ class BSController:
 
         master_state.last_commit_msg = f"Force pushed {committed} type{'' if committed == 1 else 's'}"
         self.client.master_state = master_state
+        self._flush_force_push_state()
         self.deci.info(f"Types force push successful: committed {committed} type{'' if committed == 1 else 's'}.")
 
     @init_checker
@@ -1249,6 +1309,7 @@ class BSController:
 
         master_state.last_commit_msg = f"Force pushed {committed} segments"
         self.client.master_state = master_state
+        self._flush_force_push_state()
         self.deci.info(f"Segments force push successful: committed {committed} segment{'' if committed == 1 else 's'}.")
 
     #
@@ -1549,6 +1610,50 @@ class BSController:
 
         return function_counts
 
+    def get_progress_callgraph(self):
+        import networkx as nx
+
+        fallback_to_xrefs = False
+        try:
+            graph = self.deci.get_callgraph()
+        except Exception as e:
+            _l.warning("Failed to collect decompiler callgraph for progress view: %s", e)
+            graph = nx.DiGraph()
+            fallback_to_xrefs = True
+            try:
+                self.deci.warning("Callgraph collection failed; rebuilding progress graph from code xrefs.")
+            except Exception:
+                pass
+        else:
+            graph = graph.copy() if graph is not None else nx.DiGraph()
+
+        funcs_by_addr = {
+            func.addr: func for func in self.deci.functions.values()
+            if getattr(func, "addr", None) is not None
+        }
+
+        # Some backend callgraph APIs only add functions that participate in an edge.
+        # The progress view still needs isolated and changed functions as nodes.
+        for func in funcs_by_addr.values():
+            graph.add_node(func)
+
+        if fallback_to_xrefs and hasattr(self.deci, "xrefs_to"):
+            for target_func in funcs_by_addr.values():
+                try:
+                    callers = self.deci.xrefs_to(target_func, only_code=True)
+                except Exception as e:
+                    _l.debug("Failed to collect code xrefs to %s for progress view: %s", target_func, e)
+                    continue
+
+                for caller in callers:
+                    if not isinstance(caller, Function):
+                        continue
+
+                    caller_func = funcs_by_addr.get(caller.addr, caller)
+                    graph.add_edge(caller_func, target_func)
+
+        return graph
+
     def show_progress_window(self, *args, tag=None, **kwargs):
         """
         TODO: re-enable this later when you figure out how fix the apparent thread/proccess issue in IDA Pro
@@ -1562,7 +1667,7 @@ class BSController:
         #    return
 
         self.deci.info("Collecting data to make progress view now...")
-        graph = self.deci.get_callgraph()
+        graph = self.get_progress_callgraph()
         if tag == "master":
             tag = None
 

--- a/binsync/interface_overrides/binja.py
+++ b/binsync/interface_overrides/binja.py
@@ -1,5 +1,3 @@
-from collections import defaultdict
-
 from PySide6.QtGui import QImage
 from PySide6.QtWidgets import (
     QVBoxLayout
@@ -25,8 +23,10 @@ from binsync.ui.config_dialog import ConfigureBSDialog
 class BinSyncSidebarWidget(SidebarWidget):
     def __init__(self, bv, bs_interface, name="BinSync"):
         super().__init__(name)
-        self._controller = bs_interface.controllers[bv]
-        self._controller.bv = bv
+        self._controller = bs_interface.controller_for_bv(bv)
+        if self._controller is None:
+            raise ValueError("A BinaryView is required to create the BinSync sidebar")
+
         self._widget = ControlPanel(self._controller)
 
         layout = QVBoxLayout()
@@ -61,9 +61,31 @@ class BinjaBSInterface(BinjaInterface):
     """
 
     def __init__(self, *args, **kwargs):
-        self.controllers = defaultdict(BSController)
+        self.controllers = {}
         self.sidebar_widget_type = None
         super().__init__(*args, **kwargs)
+
+    def controller_for_bv(self, bv):
+        if bv is None:
+            return None
+
+        try:
+            return self.controllers[bv]
+        except KeyError:
+            pass
+
+        deci = BinjaInterface(bv=bv)
+        controller = BSController(decompiler_interface=deci)
+        self.controllers[bv] = controller
+        return controller
+
+    def stop_controllers(self):
+        for controller in list(self.controllers.values()):
+            try:
+                controller.stop_worker_routines()
+            except Exception:
+                pass
+        self.controllers.clear()
 
     def _init_gui_components(self, *args, **kwargs):
         if super()._init_gui_components(*args, **kwargs):
@@ -80,8 +102,14 @@ class BinjaBSInterface(BinjaInterface):
             Sidebar.addSidebarWidgetType(self.sidebar_widget_type)
 
     def _launch_bs_config(self, bn_context):
-        bv = bn_context.context.getCurrentView().getData()
-        bs_controller = self.controllers[bv]
+        view = bn_context.context.getCurrentView()
+        if view is None:
+            return
+
+        bv = view.getData()
+        bs_controller = self.controller_for_bv(bv)
+        if bs_controller is None:
+            return
 
         # exit early if we already configured
         if (bs_controller.check_client() and bs_controller.deci.bv is not None) or bv is None:
@@ -89,7 +117,6 @@ class BinjaBSInterface(BinjaInterface):
 
         # configure
         self.bv = bv
-        bs_controller.deci.bv = bv
         dialog = ConfigureBSDialog(bs_controller)
         dialog.exec_()
 

--- a/binsync/interface_overrides/ghidra.py
+++ b/binsync/interface_overrides/ghidra.py
@@ -1,6 +1,9 @@
 import logging
+import os
 import sys
-import threading
+import atexit
+import tempfile
+from pathlib import Path
 from time import sleep
 import subprocess
 
@@ -15,6 +18,13 @@ from binsync.ui.config_dialog import ConfigureBSDialog
 from binsync.controller import BSController
 
 _l = logging.getLogger(__name__)
+BINSYNC_GHIDRA_SERVER_URL = "BINSYNC_GHIDRA_SERVER_URL"
+BINSYNC_GHIDRA_UI_LOG_PATH = "BINSYNC_GHIDRA_UI_LOG_PATH"
+
+
+def _ghidra_ui_log_path():
+    configured_path = os.environ.get(BINSYNC_GHIDRA_UI_LOG_PATH)
+    return Path(configured_path) if configured_path else Path(tempfile.gettempdir()) / "binsync-ghidra-ui.log"
 
 
 class ControlPanelWindow(QMainWindow):
@@ -47,7 +57,18 @@ class ControlPanelWindow(QMainWindow):
         return self.controller.check_client()
 
     def closeEvent(self, event):
-        self.controller.shutdown()
+        try:
+            self.controller.stop_worker_routines()
+        except Exception:
+            _l.exception("Failed to stop BinSync worker routines before closing Ghidra UI")
+
+        try:
+            if hasattr(self._interface, "shutdown_server"):
+                self._interface.shutdown_server()
+            else:
+                self._interface.shutdown()
+        except Exception:
+            _l.exception("Failed to shut down Ghidra remote interface")
         # Brief delay to allow threads to finish cleanup
         # With the Scheduler timeout fix, threads should exit quickly
         QTimer.singleShot(200, QApplication.quit)
@@ -55,7 +76,8 @@ class ControlPanelWindow(QMainWindow):
 
 def start_ghidra_ui():
     from declib.api.decompiler_client import DecompilerClient
-    deci = DecompilerClient.discover()
+    server_url = os.environ.get(BINSYNC_GHIDRA_SERVER_URL)
+    deci = DecompilerClient.discover(server_url=server_url) if server_url else DecompilerClient.discover()
     app = QApplication.instance()
     if app is None:
         app = QApplication(sys.argv)
@@ -82,15 +104,18 @@ class GhidraRemoteInterfaceWrapper:
     def __init__(self, *args, **kwargs):
         #import remote_pdb; remote_pdb.RemotePdb('localhost', 4444).set_trace()
         self.server = DecompilerServer(force_decompiler="ghidra")
-        #self.server.start()
-        self.server_thread = threading.Thread(target=self.server.start, daemon=True)
-        self.server_thread.run()
+        self.gui_process = None
+        self._shutdown_done = False
+        self.server.start()
+        atexit.register(self.shutdown)
         sleep(1)
         _l.info("Server started on socket: %s", self.server.socket_path)
-        self.start_gui_in_new_process()
+        self.gui_process = self.start_gui_in_new_process(socket_path=self.server.socket_path)
+        if getattr(self.server, "requires_main_thread", False):
+            self.server.wait_for_shutdown()
 
     @staticmethod
-    def start_gui_in_new_process():
+    def start_gui_in_new_process(socket_path=None):
         _l.info("Starting the Ghidra BinSync UI in a new process...")
         # Try command sets in order of preference.
         # We prefer sys.executable to ensure the current Python environment is used.
@@ -101,13 +126,24 @@ class GhidraRemoteInterfaceWrapper:
         ]
 
         proc = None
+        env = os.environ.copy()
+        if socket_path:
+            env[BINSYNC_GHIDRA_SERVER_URL] = f"unix://{socket_path}"
+        log_path = _ghidra_ui_log_path()
+        env[BINSYNC_GHIDRA_UI_LOG_PATH] = str(log_path)
+
         for cmd in commands:
             _l.info(f"Attempting to start UI with command: {' '.join(cmd)}")
+            log_file = None
             try:
+                log_path.parent.mkdir(parents=True, exist_ok=True)
+                log_file = log_path.open("a", buffering=1, encoding="utf-8")
+                log_file.write(f"\n--- Starting Ghidra BinSync UI: {' '.join(cmd)} ---\n")
                 proc = subprocess.Popen(
                     cmd,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
+                    stdout=log_file,
+                    stderr=log_file,
+                    env=env,
                     text=True
                 )
                 sleep(1)
@@ -118,19 +154,53 @@ class GhidraRemoteInterfaceWrapper:
                     _l.info(f"Successfully started UI process with PID {proc.pid}")
                     break
                 else:
-                    _l.warning(f"Process exited prematurely: {proc.stderr.read()}")
+                    _l.warning("Process exited prematurely; see Ghidra BinSync UI log: %s", log_path)
             except Exception as e:
                 _l.warning(f"Failed to run command '{cmd[0]}': {e}")
+            finally:
+                if log_file is not None:
+                    try:
+                        log_file.close()
+                    except Exception:
+                        pass
                 
         if proc is None:
              raise RuntimeError("Exhausted all methods to start the Ghidra BinSync UI.")
         
         # Check if the process exited prematurely (if the loop finished without breaking)
         if proc.poll() is not None:
-             error_output = proc.stderr.read() if proc.stderr else "Unknown error"
-             raise RuntimeError(f"Exhausted all methods to start the Ghidra BinSync UI. Last error: {error_output}")
+             raise RuntimeError("Exhausted all methods to start the Ghidra BinSync UI.")
              
         _l.info("Ghidra BinSync UI process started with PID %d", proc.pid)
+        return proc
+
+    def shutdown(self):
+        if getattr(self, "_shutdown_done", False):
+            return
+
+        self._shutdown_done = True
+        proc = getattr(self, "gui_process", None)
+        if proc is not None and proc.poll() is None:
+            _l.info("Terminating Ghidra BinSync UI process with PID %d", proc.pid)
+            try:
+                proc.terminate()
+                proc.wait(timeout=3)
+            except subprocess.TimeoutExpired:
+                _l.warning("Ghidra BinSync UI process did not exit after terminate; killing it.")
+                proc.kill()
+                try:
+                    proc.wait(timeout=1)
+                except subprocess.TimeoutExpired:
+                    _l.warning("Ghidra BinSync UI process did not exit after kill.")
+            except Exception as e:
+                _l.warning("Failed to terminate Ghidra BinSync UI process: %s", e)
+
+        server = getattr(self, "server", None)
+        if server is not None:
+            try:
+                server.stop()
+            except Exception as e:
+                _l.warning("Failed to stop Ghidra BinSync server: %s", e)
 
     @property
     def gui_plugin(self):

--- a/binsync/ui/control_panel.py
+++ b/binsync/ui/control_panel.py
@@ -94,6 +94,16 @@ class ControlPanel(QWidget):
 
     def closeEvent(self, event):
         if self.controller is not None:
+            utilities_panel = getattr(self, "_utilities_panel", None)
+            if utilities_panel is not None:
+                utilities_panel.shutdown()
+
+            if self.controller.ui_callback == self.update_callback:
+                self.controller.ui_callback = None
+
+            if self.controller.ctx_change_callback == self.ctx_callback:
+                self.controller.ctx_change_callback = None
+
             self.controller.client_init_callback = None
 
     @staticmethod

--- a/binsync/ui/panel_tabs/activity_table.py
+++ b/binsync/ui/panel_tabs/activity_table.py
@@ -212,15 +212,22 @@ class ActivityTableView(BinsyncTableView):
             user_name = self.model.row_data[idx.row()][ActivityTableModel.USERNAME_COL]
 
             menu.addSeparator()
+            # NOTE: dispatch the fills on the controller's worker thread (schedule_job)
+            # instead of calling fill_artifact/sync_all directly. Running them inline
+            # here executes the entire sync (RPCs, per-comment git commits) on the Qt
+            # GUI thread, which freezes/deadlocks the UI for the duration.
             if isinstance(func_addr, int) and func_addr > 0:
-                menu.addAction("Sync", lambda: self.controller.fill_artifact(func_addr, artifact_type=Function, user=user_name))
-            menu.addAction("Sync-All", lambda: self.controller.sync_all(user=user_name))
+                menu.addAction("Sync", lambda checked=False, addr=func_addr, name=user_name: self.controller.schedule_job(
+                    self.controller.fill_artifact, addr, artifact_type=Function, user=name))
+            menu.addAction("Sync-All", lambda checked=False, name=user_name: self.controller.schedule_job(
+                self.controller.sync_all, user=name))
 
             for_menu = menu.addMenu(f"Sync from {user_name} for...")
             for func_addr_str in self._get_valid_funcs_for_user(user_name):
                 action = for_menu.addAction(func_addr_str)
                 action.triggered.connect(
-                    lambda chk, func=func_addr_str: self.controller.fill_artifact(func_addr, artifact_type=Function, user=user_name))
+                    lambda checked=False, addr=int(func_addr_str, 16), name=user_name: self.controller.schedule_job(
+                        self.controller.fill_artifact, addr, artifact_type=Function, user=name))
 
         menu.popup(self.mapToGlobal(event.pos()))
         

--- a/binsync/ui/panel_tabs/ctx_table.py
+++ b/binsync/ui/panel_tabs/ctx_table.py
@@ -126,7 +126,9 @@ class QCTXTable(BinsyncTableView):
             menu.addSeparator()
             sync_action = QAction("Sync", parent=menu)
             sync_action.triggered.connect(
-                lambda: self.controller.fill_artifact(self.model.saved_ctx, artifact_type=Function, user=user_name)
+                lambda checked=False, addr=self.model.saved_ctx, name=user_name: self.controller.schedule_job(
+                    self.controller.fill_artifact, addr, artifact_type=Function, user=name
+                )
             )
             menu.addAction(sync_action)
             sync_action.hovered.connect(

--- a/binsync/ui/panel_tabs/functions_table.py
+++ b/binsync/ui/panel_tabs/functions_table.py
@@ -159,7 +159,10 @@ class FunctionTableView(BinsyncTableView):
             menu.addSeparator()
             if isinstance(func_addr, int) and func_addr > 0:
                 sync_action = QAction("Sync", parent=menu)
-                sync_action.triggered.connect( lambda: self.controller.fill_artifact(func_addr, artifact_type=Function, user=user_name))
+                sync_action.triggered.connect(
+                    lambda checked=False, addr=func_addr, name=user_name: self.controller.schedule_job(
+                        self.controller.fill_artifact, addr, artifact_type=Function, user=name)
+                )
                 menu.addAction(sync_action)
                 sync_action.hovered.connect(lambda act=sync_action: self.show_tooltip(func_addr, user_name, action=act))
 
@@ -168,7 +171,9 @@ class FunctionTableView(BinsyncTableView):
             for username in users:
                 action = from_menu.addAction(username)
                 action.triggered.connect(
-                    lambda checked=False, name=username: self.controller.fill_artifact(func_addr, artifact_type=Function, user=name))
+                    lambda checked=False, addr=func_addr, name=username: self.controller.schedule_job(
+                        self.controller.fill_artifact, addr, artifact_type=Function, user=name)
+                )
                 action.hovered.connect(
                     lambda name=username, act=action: self.show_tooltip(func_addr, name, action=act))
         menu.popup(self.mapToGlobal(event.pos()))

--- a/binsync/ui/panel_tabs/globals_table.py
+++ b/binsync/ui/panel_tabs/globals_table.py
@@ -152,8 +152,8 @@ class GlobalsTableView(BinsyncTableView):
                 menu.popup(self.mapToGlobal(event.pos()))
                 return
 
-            filler_func = lambda username: lambda chk=False: self.controller.fill_artifact(
-                gvar_addr, artifact_type=GlobalVariable, user=username
+            filler_func = lambda username: lambda checked=False, addr=gvar_addr, name=username: self.controller.schedule_job(
+                self.controller.fill_artifact, addr, artifact_type=GlobalVariable, user=name
             )
 
             menu.addSeparator()

--- a/binsync/ui/panel_tabs/types_table.py
+++ b/binsync/ui/panel_tabs/types_table.py
@@ -186,8 +186,8 @@ class TypesTableView(BinsyncTableView):
                 menu.popup(self.mapToGlobal(event.pos()))
                 return
 
-            filler_func = lambda username: lambda chk=False: self.controller.fill_artifact(
-                type_name, artifact_type=artifact_cls, user=username
+            filler_func = lambda username: lambda checked=False, name=type_name, cls=artifact_cls, user=username: self.controller.schedule_job(
+                self.controller.fill_artifact, name, artifact_type=cls, user=user
             )
 
             menu.addSeparator()

--- a/binsync/ui/panel_tabs/util_panel.py
+++ b/binsync/ui/panel_tabs/util_panel.py
@@ -39,6 +39,7 @@ l = logging.getLogger(__name__)
 class QUtilPanel(QWidget):
     connected_to_server = Signal(bool)
     server_context_change = Signal(dict) # type is dict[str,dict[str,int]] but we get a TypeError: bytes or ASCII string expected not 'types.GenericAlias'
+    stop_client_worker = Signal()
     
     def __init__(self, controller: BSController, parent=None):
         super().__init__(parent)
@@ -219,6 +220,7 @@ class QUtilPanel(QWidget):
         self.client_worker.moveToThread(self.client_thread)
         self.client_worker.context_change.connect(lambda new_context: self.server_context_change.emit(new_context))
         self.client_worker.client_connected.connect(lambda connected: self.connected_to_server.emit(connected))
+        self.stop_client_worker.connect(self.client_worker.stop)
         
         self.client_worker.finished.connect(self.client_thread.quit)
         self.client_thread.start()
@@ -243,9 +245,41 @@ class QUtilPanel(QWidget):
         self._aux_server_dialog.startup_emits()
         self._aux_server_dialog.exec()
 
+    def shutdown(self):
+        worker = getattr(self, "client_worker", None)
+        thread = getattr(self, "client_thread", None)
+
+        if worker is not None:
+            try:
+                stop_signal = getattr(self, "stop_client_worker", None)
+                if stop_signal is not None:
+                    stop_signal.emit()
+                else:
+                    worker.stop()
+            except RuntimeError:
+                pass
+            except Exception as e:
+                l.warning("Failed to stop auxiliary server client worker: %s", e)
+
+        if thread is not None:
+            try:
+                if not hasattr(thread, "isRunning") or thread.isRunning():
+                    thread.wait(1000)
+
+                if not hasattr(thread, "isRunning") or thread.isRunning():
+                    thread.quit()
+                    thread.wait(1000)
+            except RuntimeError:
+                pass
+            except Exception as e:
+                l.warning("Failed to stop auxiliary server client thread: %s", e)
+
+        self.client_worker = None
+        self.client_thread = None
+
     def _handle_progress_view(self):
         from ..progress_graph.progress_window import ProgressGraphWidget
-        dialog = ProgressGraphWidget(graph=self.controller.deci.get_callgraph(), controller=self.controller, parent=self)
+        dialog = ProgressGraphWidget(graph=self.controller.get_progress_callgraph(), controller=self.controller, parent=self)
         dialog.exec_()
 
     #

--- a/tests/test_binja.py
+++ b/tests/test_binja.py
@@ -1,0 +1,247 @@
+import importlib
+import sys
+import types
+
+import pytest
+
+
+class MockBaseBinjaInterface:
+    def __init__(self, *args, **kwargs):
+        self.bv = kwargs.get("bv")
+        self.artifact_watchers_started = False
+
+    def _init_gui_components(self, *args, **kwargs):
+        return True
+
+    def start_artifact_watchers(self):
+        self.artifact_watchers_started = True
+
+
+class MockController:
+    def __init__(self, decompiler_interface=None):
+        self.deci = decompiler_interface
+        self.connected = False
+        self.stopped = False
+
+    def check_client(self):
+        return self.connected
+
+    def stop_worker_routines(self):
+        self.stopped = True
+
+
+class MockSidebarWidget:
+    def __init__(self, name):
+        self.name = name
+        self.layout = None
+
+    def setLayout(self, layout):
+        self.layout = layout
+
+
+class MockLayout:
+    def __init__(self):
+        self.widgets = []
+
+    def addWidget(self, widget):
+        self.widgets.append(widget)
+
+
+def import_binja_module(monkeypatch):
+    fake_binja_interface_mod = types.ModuleType("declib.decompilers.binja.interface")
+    fake_binja_interface_mod.BinjaInterface = MockBaseBinjaInterface
+    monkeypatch.setitem(sys.modules, "declib.decompilers.binja.interface", fake_binja_interface_mod)
+
+    fake_ui = types.ModuleType("binaryninjaui")
+    fake_ui.UIAction = object
+    fake_ui.UIActionHandler = object
+    fake_ui.Menu = object
+    fake_ui.SidebarWidget = MockSidebarWidget
+    fake_ui.SidebarWidgetType = object
+    fake_ui.Sidebar = object
+    monkeypatch.setitem(sys.modules, "binaryninjaui", fake_ui)
+
+    module_name = "binsync.interface_overrides.binja"
+    parent_module = importlib.import_module("binsync.interface_overrides")
+    monkeypatch.setattr(parent_module, "binja", None, raising=False)
+    delattr(parent_module, "binja")
+    monkeypatch.setitem(sys.modules, module_name, None)
+    sys.modules.pop(module_name)
+    module = importlib.import_module(module_name)
+    monkeypatch.setattr(module, "BSController", MockController)
+    monkeypatch.setattr(module, "ControlPanel", lambda controller: {"controller": controller})
+    monkeypatch.setattr(module, "QVBoxLayout", MockLayout)
+    return module
+
+
+class TestBinja:
+    """Tests for the Binary Ninja interface override (controller cache, config launch, sidebar, shutdown).
+
+    Note: a plain class is used instead of unittest.TestCase because pytest parameterization
+    does not work on TestCase methods and results in cleaner tests.
+
+    This file covers BinjaBSInterface and its helpers in binsync/interface_overrides/binja.py:
+    per-BinaryView controller caching, the config-launch action bound to the Binary Ninja menu,
+    the BinSync sidebar widget, and shutdown of per-BV controllers. It does not cover headless
+    BSController behavior (see test_controller.py), the Ghidra remote wrapper/UI process
+    lifecycle (see test_ghidra.py), or decompiler-agnostic Qt panel shutdown and table
+    context-menu dispatch (see test_ui_panels.py).
+    """
+
+    def test_controller_per_bv(self, monkeypatch):
+        """BinjaBSInterface.controller_for_bv must cache and return one BSController per
+        BinaryView, reusing the same controller for repeated calls with the same bv and
+        creating a distinct controller (wrapping its own BinjaInterface) for a different bv.
+        A regression here would cause user state to leak across binaries or force redundant
+        controller/client setup on every call."""
+        binja = import_binja_module(monkeypatch)
+        plugin = binja.BinjaBSInterface.__new__(binja.BinjaBSInterface)
+        plugin.controllers = {}
+
+        bv_1 = object()
+        bv_2 = object()
+
+        controller_1 = plugin.controller_for_bv(bv_1)
+        controller_1_again = plugin.controller_for_bv(bv_1)
+        controller_2 = plugin.controller_for_bv(bv_2)
+
+        assert controller_1 is controller_1_again
+        assert controller_1 is not controller_2
+        assert controller_1.deci.bv is bv_1
+        assert controller_2.deci.bv is bv_2
+
+    @pytest.mark.parametrize(
+        "case",
+        ["no-view", "configures", "already-configured"],
+    )
+    def test_launch_config(self, monkeypatch, case):
+        """BinjaBSInterface._launch_bs_config must no-op when there is no active view, otherwise
+        open ConfigureBSDialog for the current BinaryView's controller and start its artifact
+        watchers once configured, and skip re-showing the dialog if that controller is already
+        configured. A regression would pop the config dialog with no view, reconfigure an
+        already-connected controller, or leave watchers unstarted after a successful config.
+        Cases cover no active view, a fresh unconfigured controller, and an already-configured
+        controller."""
+        binja = import_binja_module(monkeypatch)
+        plugin = binja.BinjaBSInterface.__new__(binja.BinjaBSInterface)
+        plugin.controllers = {}
+        bv = object()
+        configured_controllers = []
+        constructed_dialogs = []
+
+        class MockView:
+            def getData(self):
+                return bv
+
+        class MockContext:
+            def getCurrentView(self):
+                return None if case == "no-view" else MockView()
+
+        class MockActionContext:
+            context = MockContext()
+
+        class MockConfigureBSDialog:
+            def __init__(self, controller):
+                self.controller = controller
+                constructed_dialogs.append(controller)
+
+            def exec_(self):
+                configured_controllers.append(self.controller)
+                self.controller.connected = True
+
+        monkeypatch.setattr(binja, "ConfigureBSDialog", MockConfigureBSDialog)
+
+        if case == "already-configured":
+            existing_controller = plugin.controller_for_bv(bv)
+            existing_controller.connected = True
+
+        plugin._launch_bs_config(MockActionContext())
+
+        if case == "no-view":
+            assert plugin.controllers == {}
+            assert configured_controllers == []
+            return
+
+        if case == "already-configured":
+            assert constructed_dialogs == []
+            assert configured_controllers == []
+            assert plugin.controllers == {bv: existing_controller}
+            return
+
+        controller = plugin.controllers[bv]
+        assert plugin.bv is bv
+        assert configured_controllers == [controller]
+        assert controller.connected is True
+        assert controller.deci.artifact_watchers_started is True
+
+    @pytest.mark.parametrize(
+        "has_binary_view",
+        [True, False],
+        ids=["valid-view", "missing-view"],
+    )
+    def test_sidebar_requires_bv(self, monkeypatch, has_binary_view):
+        """BinSyncSidebarWidget.__init__ must raise ValueError when constructed without a
+        BinaryView (controller_for_bv returns None), and otherwise wire up the per-bv
+        controller, embed a ControlPanel built from it, and add that panel to its layout. A
+        regression would let the sidebar be created in a broken, controller-less state or fail
+        to surface the control panel to the user. Cases cover a valid BinaryView and a missing
+        one."""
+        binja = import_binja_module(monkeypatch)
+        plugin = binja.BinjaBSInterface.__new__(binja.BinjaBSInterface)
+        plugin.controllers = {}
+
+        bv = object() if has_binary_view else None
+
+        if not has_binary_view:
+            with pytest.raises(ValueError, match="BinaryView is required"):
+                binja.BinSyncSidebarWidget(bv, plugin)
+
+            assert plugin.controllers == {}
+            return
+
+        widget = binja.BinSyncSidebarWidget(bv, plugin)
+
+        assert widget._controller.deci.bv is bv
+        assert widget._widget == {"controller": widget._controller}
+        assert widget.layout.widgets == [widget._widget]
+
+    def test_stop_controllers(self, monkeypatch):
+        """BinjaBSInterface.stop_controllers must call stop_worker_routines on every tracked
+        controller, tolerating exceptions from any one controller so the remaining controllers
+        still get stopped, and must clear the controllers map afterward. A regression here
+        would let one failing controller abort shutdown of the others or leak stale controller
+        references after the plugin unloads."""
+        binja = import_binja_module(monkeypatch)
+        plugin = binja.BinjaBSInterface.__new__(binja.BinjaBSInterface)
+        stop_attempts = []
+
+        class StopController:
+            def __init__(self, name, raises=False):
+                self.name = name
+                self.raises = raises
+                self.stopped = False
+
+            def stop_worker_routines(self):
+                stop_attempts.append(self.name)
+                if self.raises:
+                    raise RuntimeError("failed to stop")
+                self.stopped = True
+
+        controllers = [
+            StopController("first"),
+            StopController("failing", raises=True),
+            StopController("last"),
+        ]
+        plugin.controllers = {object(): controller for controller in controllers}
+
+        plugin.stop_controllers()
+
+        assert stop_attempts == ["first", "failing", "last"]
+        assert controllers[0].stopped is True
+        assert controllers[1].stopped is False
+        assert controllers[2].stopped is True
+        assert plugin.controllers == {}
+
+
+if __name__ == "__main__":
+    pytest.main(args=sys.argv)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,0 +1,275 @@
+import sys
+import threading
+import tempfile
+from collections import defaultdict
+
+import networkx as nx
+import pytest
+
+from declib.artifacts import Comment, Function, GlobalVariable, Segment, Struct
+
+from binsync.controller import BSController
+from binsync.core.client import Client
+from binsync.core.state import State
+
+
+class MockDecompilerInterface:
+    name = "fake"
+    binary_hash = "fake_hash"
+    default_func_prefix = "sub_"
+
+    def __init__(self):
+        self.artifact_change_callbacks = defaultdict(list)
+        self.functions = {
+            0x400100: Function(addr=0x400100, size=0x20, name="renamed_func")
+        }
+        self.comments = {}
+        self.global_vars = {}
+        self.enums = {}
+        self.typedefs = {}
+        self.structs = {}
+        self.patches = {}
+        self.segments = {}
+
+    def get_func_size(self, addr):
+        func = self.functions.get(addr)
+        return func.size if func is not None else 0
+
+    def info(self, *_args, **_kwargs):
+        pass
+
+    def warning(self, *_args, **_kwargs):
+        pass
+
+    def shutdown(self):
+        pass
+
+    def start_artifact_watchers(self):
+        pass
+
+    def stop_artifact_watchers(self):
+        pass
+
+
+class FailingFunctionDict(dict):
+    def __setitem__(self, key, value):
+        raise RuntimeError("function set made no change")
+
+
+class FailingCallgraphDecompilerInterface(MockDecompilerInterface):
+    def get_callgraph(self):
+        raise AttributeError("'int' object has no attribute 'function'")
+
+
+class PairedFunctionDecompilerInterface(MockDecompilerInterface):
+    def __init__(self):
+        super().__init__()
+        self.functions = {
+            0x400100: Function(addr=0x400100, size=0x20, name="caller"),
+            0x400200: Function(addr=0x400200, size=0x20, name="callee"),
+        }
+
+
+class BackendCallgraphDecompilerInterface(PairedFunctionDecompilerInterface):
+    def get_callgraph(self):
+        graph = nx.DiGraph()
+        graph.add_edge(self.functions[0x400100], self.functions[0x400200])
+        return graph
+
+
+class CodeXrefDecompilerInterface(PairedFunctionDecompilerInterface):
+    def xrefs_to(self, artifact, decompile=False, only_code=False):
+        if artifact.addr == 0x400200 and only_code:
+            return [self.functions[0x400100]]
+        return []
+
+
+class TestController:
+    """Tests for BSController force-push, fill, progress-callgraph, and job-scheduling behavior.
+
+    Note: a plain class is used instead of unittest.TestCase because pytest
+    parameterization does not work on TestCase methods and results in cleaner tests.
+
+    This file covers headless BSController behavior against a fake decompiler interface:
+    persisting artifacts via force-push, filling remote artifacts into the local decompiler,
+    building the callgraph used for sync progress, and the push job scheduler. Decompiler-specific
+    interface overrides belong in test_binja.py (Binary Ninja) and test_ghidra.py (Ghidra remote
+    wrapper and UI process lifecycle); decompiler-agnostic Qt panel shutdown and table
+    context-menu dispatch belong in test_ui_panels.py.
+    """
+
+    @pytest.mark.parametrize(
+        ("artifact", "collection_name", "force_push_method", "identifier"),
+        [
+            (
+                Function(addr=0x400100, size=0x20, name="renamed_func"),
+                "functions",
+                "force_push_functions",
+                0x400100,
+            ),
+            (
+                GlobalVariable(addr=0x500000, name="global_counter", type_="int", size=4),
+                "global_vars",
+                "force_push_global_vars",
+                0x500000,
+            ),
+            (Struct(name="Record", size=8, members={}), "structs", "force_push_types", "Record"),
+            (
+                Segment(name=".text", start_addr=0x400000, end_addr=0x401000, permissions="r-x"),
+                "segments",
+                "force_push_segments",
+                ".text",
+            ),
+        ],
+        ids=("function", "global-variable", "struct", "segment"),
+    )
+    def test_force_push_persists_artifact(
+        self, artifact, collection_name, force_push_method, identifier
+    ):
+        """Confirm BSController's force_push_* methods (force_push_functions,
+        force_push_global_vars, force_push_types, force_push_segments) write the given artifact
+        into the user's Git-backed state so it survives a fresh state load, catching regressions
+        where a force-push silently drops or mis-serializes an artifact. Cases cover functions,
+        global variables, structs, and segments.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            client = Client("user0", tmpdir, "fake_hash", init_repo=True)
+            try:
+                deci = MockDecompilerInterface()
+                getattr(deci, collection_name)[identifier] = artifact
+
+                controller = BSController(decompiler_interface=deci, headless=True)
+                controller.client = client
+
+                getattr(controller, force_push_method)([identifier])
+
+                persisted_state = client.get_state(user="user0", fetch_cache=False)
+                assert getattr(persisted_state, collection_name)[identifier] == artifact
+            finally:
+                client.shutdown()
+
+    @pytest.mark.parametrize(
+        ("comment_addr", "decompiler_comment", "expected_comment"),
+        [
+            (0x400108, "raw ghidra comment", "raw ghidra comment"),
+            (
+                0x400110,
+                Comment(addr=0x400110, comment="comment artifact"),
+                "comment artifact",
+            ),
+            (0x400130, "outside function", None),
+        ],
+        ids=("raw-string", "comment-artifact", "outside-function"),
+    )
+    def test_force_push_in_range_comments(
+        self, comment_addr, decompiler_comment, expected_comment
+    ):
+        """Confirm BSController.force_push_functions only persists decompiler comments whose
+        address falls inside the pushed function's range, and normalizes both raw string comments
+        and Comment artifacts to the same persisted form with the correct func_addr; a regression
+        here would leak out-of-function comments into the pushed state or lose comment text/typing.
+        Cases cover the raw-string, Comment-artifact, and out-of-range comment forms.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            client = Client("user0", tmpdir, "fake_hash", init_repo=True)
+            try:
+                deci = MockDecompilerInterface()
+                deci.comments[comment_addr] = decompiler_comment
+                controller = BSController(decompiler_interface=deci, headless=True)
+                controller.client = client
+
+                controller.force_push_functions([0x400100])
+
+                persisted_state = client.get_state(user="user0", fetch_cache=False)
+                if expected_comment is None:
+                    assert comment_addr not in persisted_state.comments
+                else:
+                    assert persisted_state.comments[comment_addr].comment == expected_comment
+                    assert persisted_state.comments[comment_addr].func_addr == 0x400100
+            finally:
+                client.shutdown()
+
+    @pytest.mark.parametrize(
+        ("decompiler_interface_cls", "expected_nodes", "expected_edges"),
+        [
+            (BackendCallgraphDecompilerInterface, {0x400100, 0x400200}, {(0x400100, 0x400200)}),
+            (FailingCallgraphDecompilerInterface, {0x400100}, set()),
+            (CodeXrefDecompilerInterface, {0x400100, 0x400200}, {(0x400100, 0x400200)}),
+        ],
+        ids=("backend-callgraph-edge", "backend-callgraph-failure", "code-xref-edge"),
+    )
+    def test_progress_callgraph_fallbacks(
+        self, decompiler_interface_cls, expected_nodes, expected_edges
+    ):
+        """Confirm BSController.get_progress_callgraph builds a correct function callgraph when
+        the decompiler backend provides one directly, and falls back to deriving edges from
+        code cross-references when the backend's get_callgraph call fails or is unavailable; a
+        regression would leave sync-progress callgraphs missing edges or crash instead of falling
+        back. Cases cover a working backend callgraph, a backend callgraph that raises, and the
+        code-xref fallback path.
+        """
+        controller = BSController(decompiler_interface=decompiler_interface_cls(), headless=True)
+
+        graph = controller.get_progress_callgraph()
+
+        assert {func.addr for func in graph.nodes} == expected_nodes
+        assert {(src.addr, dst.addr) for src, dst in graph.edges} == expected_edges
+        for src_addr, dst_addr in expected_edges:
+            assert (controller.deci.functions[src_addr], controller.deci.functions[dst_addr]) in graph.edges
+
+    def test_fill_comments_after_function_set_noop(self):
+        """Confirm BSController.fill_artifact still fills dependent comments from a remote user
+        state even when writing the function itself into the decompiler's function dict is a
+        no-op (e.g. the decompiler rejects the write); a regression would silently drop comments
+        whenever the underlying function-set call fails to change anything.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            client = Client("user0", tmpdir, "fake_hash", init_repo=True)
+            try:
+                deci = MockDecompilerInterface()
+                deci.functions = FailingFunctionDict(deci.functions)
+                controller = BSController(decompiler_interface=deci, headless=True)
+                controller.client = client
+
+                user_state = State("user1")
+                user_state.set_function(Function(addr=0x400100, size=0x20, name="remote_name"))
+                user_state.set_comment(Comment(addr=0x400108, comment="remote comment", func_addr=0x400100))
+
+                assert controller.fill_artifact(
+                    0x400100, artifact_type=Function, state=user_state, user="user1"
+                ) is True
+                assert deci.comments[0x400108].comment == "remote comment"
+            finally:
+                client.shutdown()
+
+    @pytest.mark.parametrize(
+        ("blocking", "expected_result"),
+        [(True, "manual sync ran"), (False, None)],
+        ids=("blocking", "nonblocking"),
+    )
+    def test_schedule_job_without_auto_commit(self, blocking, expected_result):
+        """Confirm BSController.schedule_job runs the given job on the push job scheduler's worker
+        thread and, when auto-commit is disabled, returns the job's result for blocking calls
+        while returning None immediately for non-blocking calls; a regression would either block
+        forever on non-blocking scheduling or lose the job's return value. Cases cover blocking
+        and non-blocking invocation.
+        """
+        controller = BSController(decompiler_interface=MockDecompilerInterface(), headless=True)
+        controller._auto_commit_enabled = False
+        controller.push_job_scheduler.start_worker_thread()
+        job_ran = threading.Event()
+
+        def manual_sync():
+            job_ran.set()
+            return "manual sync ran"
+
+        try:
+            result = controller.schedule_job(manual_sync, blocking=blocking)
+            assert job_ran.wait(timeout=2)
+            assert result == expected_result
+        finally:
+            controller.push_job_scheduler.stop_worker_thread()
+
+
+if __name__ == "__main__":
+    pytest.main(args=sys.argv)

--- a/tests/test_ghidra.py
+++ b/tests/test_ghidra.py
@@ -1,0 +1,339 @@
+import io
+import subprocess
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+import binsync.interface_overrides.ghidra as ghidra_module
+from binsync.interface_overrides.ghidra import ControlPanelWindow, GhidraRemoteInterfaceWrapper
+
+
+class MockProcess:
+    def __init__(self, returncode=None, timeout_on_first_wait=False):
+        self.pid = 1234
+        self.stderr = io.StringIO("")
+        self.terminated = False
+        self.killed = False
+        self.waited = False
+        self.terminate_calls = 0
+        self.kill_calls = 0
+        self.wait_timeouts = []
+        self._returncode = returncode
+        self._timeout_on_first_wait = timeout_on_first_wait
+
+    def poll(self):
+        return self._returncode
+
+    def terminate(self):
+        self.terminated = True
+        self.terminate_calls += 1
+
+    def wait(self, timeout=None):
+        self.waited = True
+        self.wait_timeouts.append(timeout)
+        if self._timeout_on_first_wait and len(self.wait_timeouts) == 1:
+            raise subprocess.TimeoutExpired("ghidra-ui", timeout)
+        self._returncode = 0
+
+    def kill(self):
+        self.killed = True
+        self.kill_calls += 1
+        self._returncode = -9
+
+
+class MockServer:
+    def __init__(self):
+        self.socket_path = "/tmp/fake-ghidra.sock"
+        self.started = False
+        self.stopped = False
+        self.stop_calls = 0
+        self.waited = False
+        self.requires_main_thread = False
+
+    def start(self):
+        self.started = True
+
+    def stop(self):
+        self.stopped = True
+        self.stop_calls += 1
+
+    def wait_for_shutdown(self):
+        self.waited = True
+
+
+def _patch_popen_capture(monkeypatch, mock_proc):
+    """Patch subprocess.Popen to capture call args/kwargs and return mock_proc."""
+    popen_calls = []
+
+    def mock_popen(*args, **kwargs):
+        popen_calls.append((args, kwargs))
+        return mock_proc
+
+    monkeypatch.setattr("binsync.interface_overrides.ghidra.subprocess.Popen", mock_popen)
+    return popen_calls
+
+
+class TestGhidra:
+    """Tests for the Ghidra remote interface wrapper and UI process lifecycle.
+
+    Note: a plain class is used instead of unittest.TestCase because pytest
+    parameterization does not work on TestCase methods and results in cleaner tests.
+
+    This file covers GhidraRemoteInterfaceWrapper (launching/retrying the out-of-process
+    Ghidra UI, discovering the DecompilerClient/server URL, and tearing the UI process and
+    server down) and ControlPanelWindow.closeEvent's shutdown ordering. Headless BSController
+    behavior belongs in test_controller.py, Binary Ninja interface-override behavior in
+    test_binja.py, and decompiler-agnostic Qt panel shutdown / table context-menu dispatch in
+    test_ui_panels.py.
+    """
+
+    @pytest.mark.parametrize(
+        "socket_path",
+        [None, "/tmp/declib.sock"],
+        ids=("default-server", "explicit-server"),
+    )
+    def test_launch_server_url(self, monkeypatch, tmp_path, socket_path):
+        """GhidraRemoteInterfaceWrapper.start_gui_in_new_process must only inject
+        BINSYNC_GHIDRA_SERVER_URL into the child process env when a socket_path is given, so the
+        launched UI process picks up an explicit server address without the default-discovery
+        path being disturbed. Cases cover the default server (no socket_path) and an explicit
+        socket_path.
+        """
+        mock_proc = MockProcess()
+        monkeypatch.delenv(ghidra_module.BINSYNC_GHIDRA_SERVER_URL, raising=False)
+        monkeypatch.delenv(ghidra_module.BINSYNC_GHIDRA_UI_LOG_PATH, raising=False)
+        monkeypatch.setattr(ghidra_module.tempfile, "gettempdir", lambda: str(tmp_path))
+        monkeypatch.setattr("binsync.interface_overrides.ghidra.sleep", lambda _seconds: None)
+        popen_calls = _patch_popen_capture(monkeypatch, mock_proc)
+
+        proc = GhidraRemoteInterfaceWrapper.start_gui_in_new_process(socket_path=socket_path)
+
+        assert proc is mock_proc
+        launch_env = popen_calls[0][1]["env"]
+        if socket_path is None:
+            assert ghidra_module.BINSYNC_GHIDRA_SERVER_URL not in launch_env
+        else:
+            assert launch_env[ghidra_module.BINSYNC_GHIDRA_SERVER_URL] == f"unix://{socket_path}"
+
+    @pytest.mark.parametrize(
+        "explicit_log_path",
+        [False, True],
+        ids=("default-log-path", "explicit-log-path"),
+    )
+    def test_launch_log_path(self, monkeypatch, tmp_path, explicit_log_path):
+        """GhidraRemoteInterfaceWrapper.start_gui_in_new_process must resolve the UI log file
+        path from BINSYNC_GHIDRA_UI_LOG_PATH when set, otherwise fall back to a default path in
+        the system temp directory, and redirect both stdout and stderr of the launched process to
+        that same log file. Cases cover the default log path and an explicit log path.
+        """
+        mock_proc = MockProcess()
+        monkeypatch.delenv(ghidra_module.BINSYNC_GHIDRA_SERVER_URL, raising=False)
+        monkeypatch.delenv(ghidra_module.BINSYNC_GHIDRA_UI_LOG_PATH, raising=False)
+        monkeypatch.setattr(ghidra_module.tempfile, "gettempdir", lambda: str(tmp_path))
+        monkeypatch.setattr("binsync.interface_overrides.ghidra.sleep", lambda _seconds: None)
+
+        if explicit_log_path:
+            expected_log_path = tmp_path / "ghidra-ui.log"
+            monkeypatch.setenv(ghidra_module.BINSYNC_GHIDRA_UI_LOG_PATH, str(expected_log_path))
+        else:
+            expected_log_path = tmp_path / "binsync-ghidra-ui.log"
+
+        popen_calls = _patch_popen_capture(monkeypatch, mock_proc)
+
+        proc = GhidraRemoteInterfaceWrapper.start_gui_in_new_process(socket_path=None)
+
+        assert proc is mock_proc
+        launch_kwargs = popen_calls[0][1]
+        assert launch_kwargs["env"][ghidra_module.BINSYNC_GHIDRA_UI_LOG_PATH] == str(expected_log_path)
+        assert launch_kwargs["stdout"].name == str(expected_log_path)
+        assert launch_kwargs["stderr"] is launch_kwargs["stdout"]
+
+    @pytest.mark.parametrize(
+        "server_url",
+        [None, "unix:///tmp/declib.sock"],
+        ids=("discover-default-server", "discover-explicit-server"),
+    )
+    def test_ui_discovers_server_url(self, monkeypatch, server_url):
+        """start_ghidra_ui must call DecompilerClient.discover with the server_url read from
+        BINSYNC_GHIDRA_SERVER_URL when set, and with no server_url kwarg when the env var is
+        unset, so the UI connects to the correct backend server on startup. Cases cover the
+        default (env var unset) and an explicit server URL.
+        """
+        discover_calls = []
+        mock_deci = object()
+
+        class MockDecompilerClient:
+            @staticmethod
+            def discover(*args, **kwargs):
+                discover_calls.append((args, kwargs))
+                return mock_deci
+
+        class MockApplication:
+            @staticmethod
+            def instance():
+                return MockApplication()
+
+            def setQuitOnLastWindowClosed(self, _value):
+                pass
+
+            def exec(self):
+                pass
+
+        class MockControlPanelWindow:
+            def __init__(self, deci=None):
+                self.deci = deci
+
+            def hide(self):
+                pass
+
+            def configure(self):
+                return True
+
+            def show(self):
+                pass
+
+        monkeypatch.delenv(ghidra_module.BINSYNC_GHIDRA_SERVER_URL, raising=False)
+        if server_url is not None:
+            monkeypatch.setenv(ghidra_module.BINSYNC_GHIDRA_SERVER_URL, server_url)
+        monkeypatch.setattr("declib.api.decompiler_client.DecompilerClient", MockDecompilerClient)
+        monkeypatch.setattr(ghidra_module, "QApplication", MockApplication)
+        monkeypatch.setattr(ghidra_module, "ControlPanelWindow", MockControlPanelWindow)
+
+        ghidra_module.start_ghidra_ui()
+
+        expected_kwargs = {"server_url": server_url} if server_url is not None else {}
+        assert discover_calls == [((), expected_kwargs)]
+
+    @pytest.mark.parametrize(
+        ("returncode", "timeout_on_first_wait", "expected_terminate_calls", "expected_waits", "expected_kill_calls"),
+        [
+            (None, False, 1, [3], 0),
+            (None, True, 1, [3, 1], 1),
+            (0, False, 0, [], 0),
+        ],
+        ids=("normal-process", "timeout-and-kill", "already-exited-process"),
+    )
+    def test_wrapper_shutdown(
+        self, returncode, timeout_on_first_wait, expected_terminate_calls, expected_waits, expected_kill_calls
+    ):
+        """GhidraRemoteInterfaceWrapper.shutdown must terminate the UI process only if it is
+        still running, escalate to kill() if it does not exit within the wait timeout, always
+        stop the server exactly once, and be idempotent when called twice, so a stuck or already
+        exited Ghidra UI process never leaks or blocks shutdown. Cases cover a normal running
+        process, a process that times out on terminate and must be killed, and a process that has
+        already exited before shutdown is called.
+        """
+        mock_proc = MockProcess(returncode=returncode, timeout_on_first_wait=timeout_on_first_wait)
+        mock_server = MockServer()
+        wrapper = GhidraRemoteInterfaceWrapper.__new__(GhidraRemoteInterfaceWrapper)
+        wrapper.gui_process = mock_proc
+        wrapper.server = mock_server
+
+        wrapper.shutdown()
+        wrapper.shutdown()
+
+        assert mock_proc.terminate_calls == expected_terminate_calls
+        assert mock_proc.wait_timeouts == expected_waits
+        assert mock_proc.kill_calls == expected_kill_calls
+        assert mock_server.stopped is True
+        assert mock_server.stop_calls == 1
+
+    @pytest.mark.parametrize("requires_main_thread", [True, False], ids=("main-thread", "background-thread"))
+    def test_wrapper_main_thread_wait(self, monkeypatch, requires_main_thread):
+        """GhidraRemoteInterfaceWrapper.__init__ must start the DecompilerServer and launch the
+        UI process, and must block on server.wait_for_shutdown only when the server reports it
+        requires the main thread, so servers needing the main event loop do not return control
+        prematurely while background-thread servers do not block construction. Cases cover a
+        server that requires the main thread and one that does not.
+        """
+        mock_proc = MockProcess()
+        mock_server = MockServer()
+        mock_server.requires_main_thread = requires_main_thread
+        monkeypatch.setattr("binsync.interface_overrides.ghidra.sleep", lambda _seconds: None)
+        monkeypatch.setattr("binsync.interface_overrides.ghidra.DecompilerServer", lambda **_kwargs: mock_server)
+        monkeypatch.setattr("binsync.interface_overrides.ghidra.atexit.register", lambda _callback: None)
+        monkeypatch.setattr(
+            GhidraRemoteInterfaceWrapper,
+            "start_gui_in_new_process",
+            staticmethod(lambda socket_path=None: mock_proc),
+        )
+
+        wrapper = GhidraRemoteInterfaceWrapper()
+
+        assert wrapper.gui_process is mock_proc
+        assert mock_server.started is True
+        assert mock_server.waited is requires_main_thread
+
+    @pytest.mark.parametrize(
+        ("shutdown_method", "expected_shutdown_call"),
+        [("shutdown_server", "shutdown_server"), ("shutdown", "interface_shutdown")],
+        ids=("modern-interface", "legacy-interface"),
+    )
+    def test_control_panel_close_shutdown(self, monkeypatch, shutdown_method, expected_shutdown_call):
+        """ControlPanelWindow.closeEvent must stop the controller's worker routines, shut down
+        the remote interface (using shutdown_server on modern interfaces or shutdown on legacy
+        ones), and quit the QApplication, in that order, so closing the panel window always
+        cleanly tears down background work before the interface and app exit. Cases cover a
+        modern interface exposing shutdown_server and a legacy interface exposing only shutdown.
+        """
+        calls = []
+
+        class MockController:
+            def stop_worker_routines(self):
+                calls.append("stop_workers")
+
+            def shutdown(self):
+                calls.append("controller_shutdown")
+
+        monkeypatch.setattr("binsync.interface_overrides.ghidra.QTimer.singleShot", lambda _delay, callback: callback())
+        monkeypatch.setattr("binsync.interface_overrides.ghidra.QApplication.quit", lambda: calls.append("quit"))
+
+        remote_interface = SimpleNamespace()
+        setattr(remote_interface, shutdown_method, lambda: calls.append(expected_shutdown_call))
+        window = SimpleNamespace(controller=MockController(), _interface=remote_interface)
+
+        ControlPanelWindow.closeEvent(window, object())
+
+        assert calls == ["stop_workers", expected_shutdown_call, "quit"]
+
+    @pytest.mark.parametrize("successful_attempt", [2, None], ids=("retry-succeeds", "exhausted"))
+    def test_launch_retries_or_exhausts(self, monkeypatch, tmp_path, successful_attempt):
+        """GhidraRemoteInterfaceWrapper.start_gui_in_new_process must retry launching the UI
+        process through its fallback methods (starting with sys.executable, then the "binsync"
+        entry point) when a launch attempt exits with a failure code, and must raise a
+        RuntimeError once all methods are exhausted, so a flaky or misconfigured first launch
+        method does not permanently prevent the UI from starting. Cases cover a retry that
+        eventually succeeds and one where every method fails.
+        """
+        popen_calls = []
+        processes = []
+        monkeypatch.delenv(ghidra_module.BINSYNC_GHIDRA_UI_LOG_PATH, raising=False)
+        monkeypatch.setattr(ghidra_module.tempfile, "gettempdir", lambda: str(tmp_path))
+        monkeypatch.setattr(ghidra_module, "sleep", lambda _seconds: None)
+
+        def mock_popen(*args, **kwargs):
+            popen_calls.append((args, kwargs))
+            attempt = len(popen_calls)
+            proc = MockProcess(returncode=None if attempt == successful_attempt else 1)
+            processes.append(proc)
+            return proc
+
+        monkeypatch.setattr(ghidra_module.subprocess, "Popen", mock_popen)
+
+        if successful_attempt is None:
+            with pytest.raises(RuntimeError, match="Exhausted all methods"):
+                GhidraRemoteInterfaceWrapper.start_gui_in_new_process()
+            assert len(popen_calls) == 3
+        else:
+            proc = GhidraRemoteInterfaceWrapper.start_gui_in_new_process()
+            assert proc is processes[successful_attempt - 1]
+            assert len(popen_calls) == successful_attempt
+
+        assert popen_calls[0][0][0][0] == ghidra_module.sys.executable
+        if len(popen_calls) > 1:
+            assert popen_calls[1][0][0][0] == "binsync"
+
+
+if __name__ == "__main__":
+    pytest.main(args=sys.argv)

--- a/tests/test_ui_panels.py
+++ b/tests/test_ui_panels.py
@@ -1,0 +1,415 @@
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+import binsync.ui.panel_tabs.activity_table as activity_module
+import binsync.ui.panel_tabs.ctx_table as context_module
+import binsync.ui.panel_tabs.functions_table as functions_module
+import binsync.ui.panel_tabs.globals_table as globals_module
+import binsync.ui.panel_tabs.types_table as types_module
+from binsync.ui.control_panel import ControlPanel
+from binsync.ui.panel_tabs.activity_table import ActivityTableView
+from binsync.ui.panel_tabs.ctx_table import QCTXTable
+from binsync.ui.panel_tabs.functions_table import FunctionTableView
+from binsync.ui.panel_tabs.globals_table import GlobalsTableView
+from binsync.ui.panel_tabs.types_table import TypesTableView
+from binsync.ui.panel_tabs.util_panel import QUtilPanel
+from declib.artifacts import Function, GlobalVariable, Struct
+
+
+class MockUtilitiesPanel:
+    def __init__(self):
+        self.shutdown_called = False
+
+    def shutdown(self):
+        self.shutdown_called = True
+
+
+class MockWorker:
+    def __init__(self):
+        self.stopped = False
+
+    def stop(self):
+        self.stopped = True
+
+
+class MockSignal:
+    def __init__(self, callback=None):
+        self.callbacks = [] if callback is None else [callback]
+        self.emitted = False
+
+    def connect(self, callback):
+        self.callbacks.append(callback)
+
+    def emit(self, *args):
+        self.emitted = True
+        for callback in self.callbacks:
+            callback(*args)
+
+
+class MockThread:
+    def __init__(self, running=True, stop_on_wait=False):
+        self.quit_called = False
+        self.wait_timeouts = []
+        self._running = running
+        self._stop_on_wait = stop_on_wait
+
+    def isRunning(self):
+        return self._running
+
+    def quit(self):
+        self.quit_called = True
+        self._running = False
+
+    def wait(self, timeout):
+        self.wait_timeouts.append(timeout)
+        if self._stop_on_wait:
+            self._running = False
+
+
+class MockAction:
+    def __init__(self, text, parent=None):
+        self.text = text
+        self.parent = parent
+        self.triggered = MockSignal()
+        self.hovered = MockSignal()
+
+    def setCheckable(self, _checkable):
+        pass
+
+    def setChecked(self, _checked):
+        pass
+
+
+class MockMenu:
+    def __init__(self, parent=None, title=None):
+        self.parent = parent
+        self.title = title
+        self.actions = {}
+        self.submenus = {}
+        self.hovered = MockSignal()
+        self.aboutToHide = MockSignal()
+
+    def setObjectName(self, _name):
+        pass
+
+    def addMenu(self, title):
+        menu = MockMenu(parent=self, title=title)
+        self.submenus[title] = menu
+        return menu
+
+    def addAction(self, action_or_text, callback=None):
+        action = action_or_text if isinstance(action_or_text, MockAction) else MockAction(action_or_text, parent=self)
+        if callback is not None:
+            action.triggered.connect(callback)
+        self.actions[action.text] = action
+        return action
+
+    def addSeparator(self):
+        pass
+
+    def popup(self, _position):
+        pass
+
+
+class MockIndex:
+    @staticmethod
+    def row():
+        return 0
+
+    @staticmethod
+    def isValid():
+        return True
+
+
+class MockProxyModel:
+    @staticmethod
+    def index(_row, _column):
+        return MockIndex()
+
+    @staticmethod
+    def mapToSource(index):
+        return index
+
+
+class MockPoint:
+    @staticmethod
+    def x():
+        return -1
+
+    @staticmethod
+    def y():
+        return -1
+
+
+class MockController:
+    def __init__(self):
+        self.fill_artifact = object()
+        self.sync_all = object()
+        self.scheduled_jobs = []
+
+    def schedule_job(self, job, *args, **kwargs):
+        self.scheduled_jobs.append((job, args, kwargs))
+
+
+UI_DISPATCH_CASES = (
+    pytest.param(
+        SimpleNamespace(
+            module=activity_module,
+            view_cls=ActivityTableView,
+            row_data=[["row-user", None, 0x400100, None]],
+            action_path=("Sync",),
+            target="fill_artifact",
+            args=(0x400100,),
+            kwargs={"artifact_type": Function, "user": "row-user"},
+            valid_attr="_get_valid_funcs_for_user",
+            valid_values=("0x400200",),
+        ),
+        id="activity-sync",
+    ),
+    pytest.param(
+        SimpleNamespace(
+            module=activity_module,
+            view_cls=ActivityTableView,
+            row_data=[["row-user", None, 0x400100, None]],
+            action_path=("Sync-All",),
+            target="sync_all",
+            args=(),
+            kwargs={"user": "row-user"},
+            valid_attr="_get_valid_funcs_for_user",
+            valid_values=("0x400200",),
+        ),
+        id="activity-sync-all",
+    ),
+    pytest.param(
+        SimpleNamespace(
+            module=activity_module,
+            view_cls=ActivityTableView,
+            row_data=[["row-user", None, 0x400100, None]],
+            action_path=("Sync from row-user for...", "0x400200"),
+            target="fill_artifact",
+            args=(0x400200,),
+            kwargs={"artifact_type": Function, "user": "row-user"},
+            valid_attr="_get_valid_funcs_for_user",
+            valid_values=("0x400200",),
+        ),
+        id="activity-function-submenu",
+    ),
+    pytest.param(
+        SimpleNamespace(
+            module=context_module,
+            view_cls=QCTXTable,
+            row_data=[["row-user", "remote_name", None]],
+            saved_ctx=0x400100,
+            action_path=("Sync",),
+            target="fill_artifact",
+            args=(0x400100,),
+            kwargs={"artifact_type": Function, "user": "row-user"},
+        ),
+        id="context-sync",
+    ),
+    pytest.param(
+        SimpleNamespace(
+            module=functions_module,
+            view_cls=FunctionTableView,
+            row_data=[[0x400100, "remote_name", "row-user", None]],
+            action_path=("Sync",),
+            target="fill_artifact",
+            args=(0x400100,),
+            kwargs={"artifact_type": Function, "user": "row-user"},
+            valid_attr="_get_valid_users_for_func",
+            valid_values=("other-user",),
+        ),
+        id="function-sync",
+    ),
+    pytest.param(
+        SimpleNamespace(
+            module=functions_module,
+            view_cls=FunctionTableView,
+            row_data=[[0x400100, "remote_name", "row-user", None]],
+            action_path=("Sync from...", "other-user"),
+            target="fill_artifact",
+            args=(0x400100,),
+            kwargs={"artifact_type": Function, "user": "other-user"},
+            valid_attr="_get_valid_users_for_func",
+            valid_values=("other-user",),
+        ),
+        id="function-user-submenu",
+    ),
+    pytest.param(
+        SimpleNamespace(
+            module=globals_module,
+            view_cls=GlobalsTableView,
+            row_data=[[0x500000, "remote_global", "row-user", None]],
+            action_path=("Sync from...", "other-user"),
+            target="fill_artifact",
+            args=(0x500000,),
+            kwargs={"artifact_type": GlobalVariable, "user": "other-user"},
+            valid_attr="_get_valid_users_for_gvar",
+            valid_values=("other-user",),
+        ),
+        id="global-user-submenu",
+    ),
+    pytest.param(
+        SimpleNamespace(
+            module=types_module,
+            view_cls=TypesTableView,
+            row_data=[["Struct", "remote_type", "row-user", None]],
+            action_path=("Sync from...", "other-user"),
+            target="fill_artifact",
+            args=("remote_type",),
+            kwargs={"artifact_type": Struct, "user": "other-user"},
+            valid_attr="_get_valid_users_for_type",
+            valid_values=("other-user",),
+        ),
+        id="type-user-submenu",
+    ),
+)
+
+
+class TestUIPanels:
+    """Tests for control-panel/util-panel shutdown and table context-menu sync dispatch.
+
+    Note: a plain class is used instead of unittest.TestCase because pytest
+    parameterization does not work on TestCase methods and results in cleaner tests.
+
+    This file covers decompiler-agnostic Qt UI behavior: ControlPanel and QUtilPanel
+    teardown on close/shutdown, and the sync-dispatch context menus built by the panel
+    tab table views (activity, ctx, functions, globals, types). It does not test any
+    specific decompiler integration or headless BSController logic — those live in
+    test_binja.py, test_ghidra.py, and test_controller.py respectively.
+    """
+
+    @pytest.mark.parametrize("callbacks_owned", [True, False], ids=("owned", "foreign"))
+    def test_control_panel_close_callbacks(self, callbacks_owned):
+        """Verify ControlPanel.closeEvent shuts down the utilities panel and clears only the
+        controller callbacks the panel itself owns, leaving callbacks registered by another
+        panel instance untouched. A regression here would either leak a stale UI callback
+        pointing at a destroyed panel or wrongly clear a live panel's callback out from under
+        it. Cases cover the panel owning the controller's callbacks versus a foreign panel
+        owning them.
+        """
+        controller = SimpleNamespace()
+        utilities_panel = MockUtilitiesPanel()
+        panel = SimpleNamespace(
+            controller=controller,
+            _utilities_panel=utilities_panel,
+            update_callback=object(),
+            ctx_callback=object(),
+        )
+        foreign_update_callback = object()
+        foreign_ctx_callback = object()
+        controller.ui_callback = panel.update_callback if callbacks_owned else foreign_update_callback
+        controller.ctx_change_callback = panel.ctx_callback if callbacks_owned else foreign_ctx_callback
+        controller.client_init_callback = object()
+
+        ControlPanel.closeEvent(panel, object())
+
+        assert utilities_panel.shutdown_called is True
+        assert controller.ui_callback is (None if callbacks_owned else foreign_update_callback)
+        assert controller.ctx_change_callback is (None if callbacks_owned else foreign_ctx_callback)
+        assert controller.client_init_callback is None
+
+    @pytest.mark.parametrize(
+        ("running", "stop_on_wait", "use_signal", "expected_quit", "expected_waits"),
+        [
+            (True, True, True, False, [1000]),
+            (True, False, True, True, [1000, 1000]),
+            (False, False, False, False, []),
+        ],
+        ids=("stops-during-first-wait", "requires-quit", "already-stopped-without-signal"),
+    )
+    def test_util_panel_shutdown(
+        self, running, stop_on_wait, use_signal, expected_quit, expected_waits
+    ):
+        """Verify QUtilPanel.shutdown stops the auxiliary-server client worker (preferring the
+        stop_client_worker signal when present, otherwise calling worker.stop() directly), waits
+        for the client thread to finish, only force-quits the thread if it is still running after
+        the first wait, and clears both client_worker and client_thread references afterward. A
+        regression here would leave a background thread or worker running after panel shutdown,
+        or leak references that block garbage collection. Cases cover a thread that stops during
+        the first wait, a thread that requires an explicit quit, and a thread that is already
+        stopped with no stop signal available.
+        """
+        worker = MockWorker()
+        thread = MockThread(running=running, stop_on_wait=stop_on_wait)
+        panel = SimpleNamespace(
+            client_worker=worker,
+            client_thread=thread,
+            stop_client_worker=MockSignal(worker.stop) if use_signal else None,
+        )
+
+        QUtilPanel.shutdown(panel)
+
+        assert worker.stopped is True
+        assert thread.quit_called is expected_quit
+        assert thread.wait_timeouts == expected_waits
+        assert panel.client_worker is None
+        assert panel.client_thread is None
+
+    @pytest.mark.parametrize("case", UI_DISPATCH_CASES)
+    def test_sync_actions_schedule_jobs(self, monkeypatch, case):
+        """Verify each panel tab table view's contextMenuEvent builds a right-click sync menu
+        (a direct Sync action, a Sync-All action, and/or a per-user "Sync from..." submenu) and
+        that triggering an action schedules the correct controller job — fill_artifact or
+        sync_all — with the artifact type, address/name, and target user matching the clicked
+        row and menu entry. A regression here would silently sync the wrong user's data, the
+        wrong artifact, or fail to schedule any job when a user right-clicks a row. Cases cover
+        the activity, ctx, function, global, and type table views, exercising the direct-sync,
+        sync-all, and per-user submenu action paths for each.
+        """
+        root_menus = []
+
+        def make_menu(parent=None):
+            menu = MockMenu(parent=parent)
+            root_menus.append(menu)
+            return menu
+
+        monkeypatch.setattr(case.module, "QMenu", make_menu)
+        monkeypatch.setattr(case.module, "QAction", MockAction)
+
+        controller = MockController()
+        model = SimpleNamespace(
+            row_data=case.row_data,
+            saved_ctx=getattr(case, "saved_ctx", None),
+        )
+        table = SimpleNamespace(
+            controller=controller,
+            model=model,
+            proxymodel=MockProxyModel(),
+            HEADER=case.view_cls.HEADER,
+            column_visibility=[True] * len(case.view_cls.HEADER),
+            rowAt=lambda _y: 0,
+            mapToGlobal=lambda point: point,
+            _col_hide_handler=lambda _index: None,
+            reset_tooltip_state=lambda: None,
+            bind_tooltip_menu=lambda _menu: None,
+            handle_menu_hovered_action=lambda _action: None,
+            show_tooltip=lambda *_args, **_kwargs: None,
+        )
+        for attr in ("COL_ADDR", "COL_KIND", "COL_NAME", "COL_USER"):
+            if hasattr(case.view_cls, attr):
+                setattr(table, attr, getattr(case.view_cls, attr))
+
+        valid_attr = getattr(case, "valid_attr", None)
+        if valid_attr == "_get_valid_users_for_type":
+            setattr(table, valid_attr, lambda _name, _kind: iter(case.valid_values))
+        elif valid_attr is not None:
+            setattr(table, valid_attr, lambda _identifier: iter(case.valid_values))
+
+        event = SimpleNamespace(pos=lambda: MockPoint())
+        case.view_cls.contextMenuEvent(table, event)
+
+        menu = root_menus[0]
+        for submenu_name in case.action_path[:-1]:
+            menu = menu.submenus[submenu_name]
+        menu.actions[case.action_path[-1]].triggered.emit(False)
+
+        assert controller.scheduled_jobs == [
+            (getattr(controller, case.target), case.args, case.kwargs)
+        ]
+
+
+if __name__ == "__main__":
+    pytest.main(args=sys.argv)


### PR DESCRIPTION
## Summary

Supersedes #524, #525, #526, #527, and #528 — this PR consolidates those changes into a
single reviewed branch with regression test suites covering all the touched code paths.

Fixes several reliability issues hit while using BinSync day-to-day across Binary Ninja
and Ghidra.

### Force push
- `force_push_functions` now also collects and commits the comments inside each pushed
  function (closes the standing TODO — previously force-pushing a function silently left
  its comments behind). Commit messages include the comment count.
- All four `force_push_*` paths commit the master state synchronously at action time, so
  a force push lands in the repo immediately instead of waiting on — or being silently
  lost without — the next auto-commit tick.

### Sync dispatch
- `schedule_job` no longer silently drops jobs when auto-commit is disabled: manual
  Sync / Sync-All actions now work regardless of the toggle, which only governs
  automatic committing.
- All five table context menus (activity, ctx, functions, globals, types) dispatch sync
  work through the job scheduler instead of running RPCs and per-comment git commits
  inline on the Qt GUI thread, which froze (and could deadlock) the UI. Also fixes a
  closure bug where every entry in the activity table's "Sync from X for..." submenu
  synced the row's own function rather than the one clicked.
- `fill_artifact` isolates the decompiler write: a benign no-op set (e.g. the function
  already has that name) no longer aborts the address-keyed comment sync that follows.

### Progress view
- New `BSController.get_progress_callgraph()`: tolerates backend `get_callgraph()`
  failures by falling back to code xrefs, and always adds isolated/changed functions as
  nodes (some backend callgraph APIs only include edge-participating functions).

### Ghidra remote UI lifecycle
- UI subprocess output goes to a persistent log file (`BINSYNC_GHIDRA_UI_LOG_PATH`,
  default `<tempdir>/binsync-ghidra-ui.log`) instead of unread pipes, so startup
  failures are diagnosable.
- The child UI process is pointed at the server explicitly via
  `BINSYNC_GHIDRA_SERVER_URL` rather than relying purely on discovery.
- Idempotent shutdown registered via `atexit`: terminates the UI process (terminate →
  kill escalation) and stops the `DecompilerServer`; `closeEvent` stops worker routines
  and shuts down the remote interface before quitting. No more zombie UI processes.

### Binary Ninja lifecycle
- Per-BinaryView controller cache rebuilt around a `controller_for_bv()` factory,
  replacing the `defaultdict` that created controllers with no BinaryView bound to
  their decompiler interface. The sidebar fails fast without a BinaryView, and the
  configure action no-ops instead of crashing when there is no current view.

### UI panel shutdown
- `ControlPanel.closeEvent` clears only the controller callbacks it owns and tears down
  the utilities panel; new `QUtilPanel.shutdown()` stops the aux-server client thread
  with bounded waits instead of leaking it.

## Tests

Four new suites — `test_controller.py`, `test_binja.py`, `test_ghidra.py`,
`test_ui_panels.py` — 19 tests / 48 parameterized cases, all runnable without a live
decompiler (fakes at the declib boundary, offscreen Qt). Wired into CI: core-tests runs
the controller suite; gui-tests runs the three GUI suites.

Style note: the suites use plain pytest classes rather than `unittest.TestCase` because
pytest parameterization doesn't work on TestCase methods (`test_angr_gui.py` precedent).

## Notes for reviewers

Two deliberate changes worth sign-off:
- The auto-commit toggle no longer gates `schedule_job` — manual jobs always run.
- Force push performs its git commit (and pull/push when a remote is configured)
  synchronously within the action rather than queueing for the background committer. 
